### PR TITLE
Reformat the create activity page, so it can handle multiple semesters

### DIFF
--- a/prisma/migrations/20230319201312_init/migration.sql
+++ b/prisma/migrations/20230319201312_init/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Activity" ALTER COLUMN "dateModified" SET DEFAULT extract(epoch from now())::bigint;

--- a/prisma/migrations/20230319203529_init/migration.sql
+++ b/prisma/migrations/20230319203529_init/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Activity" ALTER COLUMN "dateModified" SET DEFAULT extract(epoch from now())::bigint;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,17 +32,18 @@ model ProfessorInfo {
 }
 
 model Activity {
-  id           Int               @id @default(autoincrement())
-  user         User              @relation(fields: [userId], references: [id])
-  userId       Int
-  year         Int
-  semester     Semester[]
-  dateModified BigInt            @default(dbgenerated("extract(epoch from now())::bigint"))
-  name         String
-  description  String
-  category     ActivityCategory
-  significance SignificanceLevel
-  isFavorite   Boolean
+  id                       Int               @id @default(autoincrement())
+  user                     User              @relation(fields: [userId], references: [id])
+  userId                   Int
+  year                     Int
+  semester                 Semester[]
+  dateModified             BigInt            @default(dbgenerated("extract(epoch from now())::bigint"))
+  name                     String
+  description              String
+  semesterOtherDescription String?
+  category                 ActivityCategory
+  significance             SignificanceLevel
+  isFavorite               Boolean
 }
 
 model Narrative {

--- a/src/components/ActivityForm/FormContainer.tsx
+++ b/src/components/ActivityForm/FormContainer.tsx
@@ -5,26 +5,9 @@ import FormInstructions from './FormInstructions';
 
 const FormContainer: React.FC<{ children: JSX.Element }> = ({ children }) => {
   const step: FormStep = useSelector(selectStep);
-  //const stepOne = step === 'selection';
   return (
-    <div className="flex h-full">
-      <div className="px-8 pb-20">
-        {
-          /*
-          <div className="w-full mt-2">
-            <div className="bg-neutral-300 w-full h-3 rounded">
-              <div
-                className={`bg-ruby h-full rounded ${
-                  stepOne ? 'w-1/2' : 'w-full'
-                }`}
-              />
-            </div>
-            <p className="mt-3 text-right">Page {stepOne ? '1' : '2'}/2</p>
-          </div>
-          */
-        }
-        {children}
-      </div>
+    <div className="flex w-full h-full">
+      <div className="px-8 pb-20 w-full">{children}</div>
     </div>
   );
 };

--- a/src/components/ActivityForm/FormInput.tsx
+++ b/src/components/ActivityForm/FormInput.tsx
@@ -5,12 +5,14 @@ import {
   selectDate,
   selectDescription,
   selectName,
+  selectOtherDescription,
   selectSemester,
   selectWeight,
   selectYear,
   setDate,
   setDescription,
   setName,
+  setOtherDescription,
   setSemester,
   setStep,
   setWeight,
@@ -46,6 +48,8 @@ const FormInput: React.FC = () => {
   const year: number | null = useSelector(selectYear);
   const date: string = useSelector(selectDate);
   const description: string = useSelector(selectDescription);
+  const otherDescription: string | null = useSelector(selectOtherDescription);
+
   const [specifyDate, setSpecifyDate] = useState(false);
   const [checkFall, setCheckFall] = useState(false);
   const [checkSpring, setCheckSpring] = useState(false);
@@ -115,6 +119,32 @@ const FormInput: React.FC = () => {
     }
   };
 
+  const handleOtherDescriptionChange: ChangeEventHandler<
+    HTMLTextAreaElement
+  > = (event) => {
+    const newOtherDescription: string = event.target.value;
+    dispatch(setOtherDescription(newOtherDescription));
+  };
+
+  const displayOtherDescription = () => {
+    return (
+      <div className={inputContainer}>
+        <div className={inputWrapper}>
+          <p className={'text-slate-600'}>
+            If you checked Other, please explain in the below.
+          </p>
+          <div className={inputStatus + ' ml-auto'}></div>
+        </div>
+        <textarea
+          value={otherDescription || ''}
+          onChange={handleOtherDescriptionChange}
+          rows={3}
+          className={inputBox}
+        />
+      </div>
+    );
+  };
+
   const changeToDate: FocusEventHandler<HTMLInputElement> = (event) => {
     event.target.type = 'date';
   };
@@ -133,6 +163,8 @@ const FormInput: React.FC = () => {
       !name ||
       !semester ||
       !year ||
+      (!checkFall && !checkOther && !checkSpring && !checkSummer) ||
+      (checkOther && !otherDescription) ||
       (specifyDate && !date)
     )
       return;
@@ -150,6 +182,7 @@ const FormInput: React.FC = () => {
       category: category,
       significance: weight,
       isFavorite: true,
+      semesterOtherDescription: otherDescription,
     };
     console.log(newActivityDto);
     dispatch(setStep('loading'));
@@ -278,8 +311,6 @@ const FormInput: React.FC = () => {
             value={checkFall}
             onChange={(event) => {
               setCheckFall(!checkFall);
-              // console.log(e.target.parentElement?.textContent?.trim());
-
               checkFall
                 ? handleRemoveSemester(event)
                 : handleAddSemester(event);
@@ -316,7 +347,7 @@ const FormInput: React.FC = () => {
             }}
           />
         </div>
-        <div className={inputStatus + ' mt-auto mb-2'}>
+        <div className={inputStatus}>
           <Image
             src={
               checkFall || checkSpring || checkOther || checkSummer
@@ -328,11 +359,12 @@ const FormInput: React.FC = () => {
             height={16}
             className="mx-2"
           />
-          {(!semester || !year) && (
+          {!checkFall && !checkSpring && !checkOther && !checkSummer && (
             <p className="text-ruby inline">Select semesters.</p>
           )}
         </div>
       </div>
+      {checkOther ? displayOtherDescription() : ''}
       {specifyDate && (
         <div className={inputContainer}>
           <p className={label}>Date: </p>
@@ -380,7 +412,14 @@ const FormInput: React.FC = () => {
         <button onClick={() => dispatch(setStep('selection'))}>Back</button>
         <button
           className="bg-ruby border-ruby-dark text-white disabled:bg-ruby-disabled"
-          disabled={weight === null || date === null || description === ''}
+          disabled={
+            weight === null ||
+            date === null ||
+            description === '' ||
+            !semester ||
+            !name ||
+            (checkOther && !otherDescription)
+          }
           onClick={submitActivity}
         >
           Submit

--- a/src/components/ActivityForm/FormInput.tsx
+++ b/src/components/ActivityForm/FormInput.tsx
@@ -222,6 +222,28 @@ const FormInput: React.FC = () => {
           </div>
         </div>
       </div>
+      <div className={inputContainer}>
+        <p className={label}>Year: </p>
+        <input
+          type={'text'}
+          placeholder="Enter Year"
+          onChange={handleYearChange}
+          value={year || ''}
+          className={inputBox}
+        ></input>
+        <div className={inputStatus}>
+          <Image
+            src={
+              year ? '/media/successCheckmark.svg' : '/media/failureWarning.svg'
+            }
+            alt="Icon"
+            width={16}
+            height={16}
+            className="mx-2"
+          />
+          {!year && <p className="text-ruby inline">Enter an year.</p>}
+        </div>
+      </div>
       <div className="flex space-x-6">
         <div className={inputContainer}>
           <p className={label}>Semester: </p>
@@ -237,16 +259,6 @@ const FormInput: React.FC = () => {
               </option>
             ))}
           </select>
-        </div>
-        <div className={inputContainer}>
-          <p className={label}>Year: </p>
-          <input
-            type={'text'}
-            placeholder="Enter Year"
-            onChange={handleYearChange}
-            value={year || ''}
-            className={inputBox}
-          ></input>
         </div>
         <div className={inputStatus + ' mt-auto mb-2'}>
           <Image

--- a/src/components/ActivityForm/FormInput.tsx
+++ b/src/components/ActivityForm/FormInput.tsx
@@ -80,16 +80,20 @@ const FormInput: React.FC = () => {
 
   const handleAddSemester: ChangeEventHandler<HTMLSelectElement> = (event) => {
     const newSemester: Semester = event.target.value as Semester;
-    if (newSemester) {
-      //if ()
-      dispatch(setSemester([newSemester]));
-    }
+    console.log(event.target.value);
+
+    dispatch(setSemester([newSemester]));
   };
 
   const handleRemoveSemester: ChangeEventHandler<HTMLSelectElement> = (
     event,
   ) => {
     const newSemester: Semester = event.target.value as Semester;
+    console.log(newSemester);
+    if (semester) {
+      const removed_semester = semester.filter((item) => item !== newSemester);
+      dispatch(setSemester(removed_semester));
+    }
   };
 
   const handleYearChange: ChangeEventHandler<HTMLInputElement> = (event) => {
@@ -261,26 +265,38 @@ const FormInput: React.FC = () => {
       <div className="flex space-x-6">
         <div className={inputContainer}>
           <p className={label}>Semester: </p>
-
+          {/* This could be a map but woo wee lazy, rip me at PR if you want it */}
           <Checkbox
             label="Fall"
             value={checkFall}
-            onChange={checkFall ? handleAddSemester : handleRemoveSemester}
+            onChange={() => {
+              setCheckFall(!checkFall);
+              return checkFall ? handleAddSemester : handleRemoveSemester;
+            }}
           />
           <Checkbox
             label="Spring"
             value={checkSpring}
-            onChange={checkSpring ? handleAddSemester : handleRemoveSemester}
+            onChange={() => {
+              setCheckSpring(!checkSpring);
+              return checkSpring ? handleAddSemester : handleRemoveSemester;
+            }}
           />
           <Checkbox
             label="Summer"
             value={checkSummer}
-            onChange={checkSummer ? handleAddSemester : handleRemoveSemester}
+            onChange={() => {
+              setCheckSpring(!checkSummer);
+              return checkSummer ? handleAddSemester : handleRemoveSemester;
+            }}
           />
           <Checkbox
             label="Other"
             value={checkOther}
-            onChange={checkOther ? handleAddSemester : handleRemoveSemester}
+            onChange={() => {
+              setCheckSpring(!checkOther);
+              return checkOther ? handleAddSemester : handleRemoveSemester;
+            }}
           />
         </div>
         <div className={inputStatus + ' mt-auto mb-2'}>

--- a/src/components/ActivityForm/FormInput.tsx
+++ b/src/components/ActivityForm/FormInput.tsx
@@ -78,24 +78,29 @@ const FormInput: React.FC = () => {
     dispatch(setName(newName));
   };
 
-  const handleAddSemester: ChangeEventHandler<HTMLSelectElement> = (event) => {
-    const newSemester: Semester = event.target.value as Semester;
-    console.log(event.target.value);
+  const handleAddSemester: ChangeEventHandler<Element> = (event) => {
+    const newSemester: Semester = event.target.parentElement?.textContent
+      ?.trim()
+      .toLocaleUpperCase() as Semester;
     if (semester) {
       const added_semester = [...semester, newSemester];
       dispatch(setSemester(added_semester));
+    } else {
+      dispatch(setSemester([newSemester]));
     }
+    console.log('added' + semester);
   };
 
-  const handleRemoveSemester: ChangeEventHandler<HTMLSelectElement> = (
-    event,
-  ) => {
-    const newSemester: Semester = event.target.value as Semester;
-    console.log(newSemester);
+  const handleRemoveSemester: ChangeEventHandler<Element> = (event) => {
+    const newSemester: Semester = event.target.parentElement?.textContent
+      ?.trim()
+      .toLocaleUpperCase() as Semester;
+
     if (semester) {
       const removed_semester = semester.filter((item) => item !== newSemester);
       dispatch(setSemester(removed_semester));
     }
+    console.log('removed' + semester);
   };
 
   const handleYearChange: ChangeEventHandler<HTMLInputElement> = (event) => {
@@ -271,40 +276,50 @@ const FormInput: React.FC = () => {
           <Checkbox
             label="Fall"
             value={checkFall}
-            onChange={() => {
+            onChange={(event) => {
               setCheckFall(!checkFall);
-              return checkFall ? handleAddSemester : handleRemoveSemester;
+              // console.log(e.target.parentElement?.textContent?.trim());
+
+              checkFall
+                ? handleRemoveSemester(event)
+                : handleAddSemester(event);
             }}
           />
           <Checkbox
             label="Spring"
             value={checkSpring}
-            onChange={() => {
+            onChange={(event) => {
               setCheckSpring(!checkSpring);
-              return checkSpring ? handleAddSemester : handleRemoveSemester;
+              checkSpring
+                ? handleRemoveSemester(event)
+                : handleAddSemester(event);
             }}
           />
           <Checkbox
             label="Summer"
             value={checkSummer}
-            onChange={() => {
-              setCheckSpring(!checkSummer);
-              return checkSummer ? handleAddSemester : handleRemoveSemester;
+            onChange={(event) => {
+              setCheckSummer(!checkSummer);
+              checkSummer
+                ? handleRemoveSemester(event)
+                : handleAddSemester(event);
             }}
           />
           <Checkbox
             label="Other"
             value={checkOther}
-            onChange={() => {
-              setCheckSpring(!checkOther);
-              return checkOther ? handleAddSemester : handleRemoveSemester;
+            onChange={(event) => {
+              setCheckOther(!checkOther);
+              checkOther
+                ? handleRemoveSemester(event)
+                : handleAddSemester(event);
             }}
           />
         </div>
         <div className={inputStatus + ' mt-auto mb-2'}>
           <Image
             src={
-              semester && year
+              checkFall || checkSpring || checkOther || checkSummer
                 ? '/media/successCheckmark.svg'
                 : '/media/failureWarning.svg'
             }

--- a/src/components/ActivityForm/FormInput.tsx
+++ b/src/components/ActivityForm/FormInput.tsx
@@ -194,15 +194,15 @@ const FormInput: React.FC = () => {
   if (category === null) return <div>Category must be selected</div>;
 
   // TODO: reduce redundancy of multiple inputs
-  const label = 'text-2xl font-bold';
+  const label = 'text-base font-bold';
   const inputBox = 'border border-black rounded-lg px-3 py-2 outline-none';
-  const inputContainer = 'flex flex-col my-2 space-y-3';
+  const inputContainer = 'flex flex-col my-2 space-y-1';
   const inputWrapper = 'flex items-center';
   const inputStatus = 'flex items-center py-3';
 
   return (
     <div className="flex flex-col">
-      <p className="text-3xl mb-3">{categoryLabels[category]}</p>
+      <h2>New Activity - {categoryLabels[category]}</h2>
       <div className={inputContainer}>
         <p className={label}>Name: </p>
         <div className={inputWrapper}>

--- a/src/components/ActivityForm/FormInput.tsx
+++ b/src/components/ActivityForm/FormInput.tsx
@@ -27,6 +27,7 @@ import Tooltip from '../../shared/components/Tooltip';
 import { createActivity, ResponseStatus } from '@/client/activities.client';
 import Image from 'next/image';
 import { useSession } from 'next-auth/react';
+import { Checkbox } from '../Checkbox';
 
 const categoryLabels: Record<ActivityCategory, string> = {
   TEACHING: 'Teaching',
@@ -41,11 +42,15 @@ const FormInput: React.FC = () => {
   const category: ActivityCategory | null = useSelector(selectCategory);
   const name: string | null = useSelector(selectName);
   const weight: ActivityWeight | null = useSelector(selectWeight);
-  const semester: Semester | null = useSelector(selectSemester);
+  const semester: Semester[] | null = useSelector(selectSemester);
   const year: number | null = useSelector(selectYear);
   const date: string = useSelector(selectDate);
   const description: string = useSelector(selectDescription);
   const [specifyDate, setSpecifyDate] = useState(false);
+  const [checkFall, setCheckFall] = useState(false);
+  const [checkSpring, setCheckSpring] = useState(false);
+  const [checkSummer, setCheckSummer] = useState(false);
+  const [checkOther, setCheckOther] = useState(false);
 
   const dispatch = useDispatch();
 
@@ -73,13 +78,18 @@ const FormInput: React.FC = () => {
     dispatch(setName(newName));
   };
 
-  const handleSemesterChange: ChangeEventHandler<HTMLSelectElement> = (
+  const handleAddSemester: ChangeEventHandler<HTMLSelectElement> = (event) => {
+    const newSemester: Semester = event.target.value as Semester;
+    if (newSemester) {
+      //if ()
+      dispatch(setSemester([newSemester]));
+    }
+  };
+
+  const handleRemoveSemester: ChangeEventHandler<HTMLSelectElement> = (
     event,
   ) => {
     const newSemester: Semester = event.target.value as Semester;
-    if (newSemester) {
-      dispatch(setSemester(newSemester));
-    }
   };
 
   const handleYearChange: ChangeEventHandler<HTMLInputElement> = (event) => {
@@ -120,7 +130,7 @@ const FormInput: React.FC = () => {
 
     const newActivityDto: CreateActivityDto = {
       userId: userId || 1,
-      semester: [semester],
+      semester: semester,
       year: year,
       //date : dateObject ? dateObject.getTime() : undefined,
       dateModified: BigInt(new Date().getTime()),
@@ -244,25 +254,34 @@ const FormInput: React.FC = () => {
               height={16}
               className="mx-2"
             />
-            {!year && <p className="text-ruby inline">Enter an year.</p>}
+            {!year && <p className="text-ruby inline">Enter year.</p>}
           </div>
         </div>
       </div>
       <div className="flex space-x-6">
         <div className={inputContainer}>
           <p className={label}>Semester: </p>
-          <select
-            value={semester || ''}
-            onChange={handleSemesterChange}
-            className={inputBox}
-          >
-            <option value="">Select Semester</option>
-            {['Fall', 'Spring', 'Summer', 'Other'].map((sem) => (
-              <option value={sem.toUpperCase()} key={sem}>
-                {sem}
-              </option>
-            ))}
-          </select>
+
+          <Checkbox
+            label="Fall"
+            value={checkFall}
+            onChange={checkFall ? handleAddSemester : handleRemoveSemester}
+          />
+          <Checkbox
+            label="Spring"
+            value={checkSpring}
+            onChange={checkSpring ? handleAddSemester : handleRemoveSemester}
+          />
+          <Checkbox
+            label="Summer"
+            value={checkSummer}
+            onChange={checkSummer ? handleAddSemester : handleRemoveSemester}
+          />
+          <Checkbox
+            label="Other"
+            value={checkOther}
+            onChange={checkOther ? handleAddSemester : handleRemoveSemester}
+          />
         </div>
         <div className={inputStatus + ' mt-auto mb-2'}>
           <Image
@@ -277,7 +296,7 @@ const FormInput: React.FC = () => {
             className="mx-2"
           />
           {(!semester || !year) && (
-            <p className="text-ruby inline">Enter a semester and year.</p>
+            <p className="text-ruby inline">Select semesters.</p>
           )}
         </div>
       </div>

--- a/src/components/ActivityForm/FormInput.tsx
+++ b/src/components/ActivityForm/FormInput.tsx
@@ -224,24 +224,28 @@ const FormInput: React.FC = () => {
       </div>
       <div className={inputContainer}>
         <p className={label}>Year: </p>
-        <input
-          type={'text'}
-          placeholder="Enter Year"
-          onChange={handleYearChange}
-          value={year || ''}
-          className={inputBox}
-        ></input>
-        <div className={inputStatus}>
-          <Image
-            src={
-              year ? '/media/successCheckmark.svg' : '/media/failureWarning.svg'
-            }
-            alt="Icon"
-            width={16}
-            height={16}
-            className="mx-2"
-          />
-          {!year && <p className="text-ruby inline">Enter an year.</p>}
+        <div className={inputWrapper}>
+          <input
+            type={'text'}
+            placeholder="Enter Year"
+            onChange={handleYearChange}
+            value={year || ''}
+            className={inputBox}
+          ></input>
+          <div className={inputStatus}>
+            <Image
+              src={
+                year
+                  ? '/media/successCheckmark.svg'
+                  : '/media/failureWarning.svg'
+              }
+              alt="Icon"
+              width={16}
+              height={16}
+              className="mx-2"
+            />
+            {!year && <p className="text-ruby inline">Enter an year.</p>}
+          </div>
         </div>
       </div>
       <div className="flex space-x-6">

--- a/src/components/ActivityForm/FormInput.tsx
+++ b/src/components/ActivityForm/FormInput.tsx
@@ -81,8 +81,10 @@ const FormInput: React.FC = () => {
   const handleAddSemester: ChangeEventHandler<HTMLSelectElement> = (event) => {
     const newSemester: Semester = event.target.value as Semester;
     console.log(event.target.value);
-
-    dispatch(setSemester([newSemester]));
+    if (semester) {
+      const added_semester = [...semester, newSemester];
+      dispatch(setSemester(added_semester));
+    }
   };
 
   const handleRemoveSemester: ChangeEventHandler<HTMLSelectElement> = (

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -1,0 +1,13 @@
+import React, { ChangeEventHandler } from 'react';
+
+interface CheckboxProps {label: string, value: boolean, onChange: ChangeEventHandler};
+
+export const Checkbox: React.FC<CheckboxProps> = ({label, value, onChange}: CheckboxProps) => {
+    return (
+        <label>
+            <input type="checkbox" checked={value} onChange={onChange} />
+            {label}
+        </label>
+    );
+};
+

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -12,7 +12,6 @@ export const Checkbox: React.FC<CheckboxProps> = ({
   onChange,
 }: CheckboxProps) => {
   return (
-<<<<<<< HEAD
     <label className={'flex justify-start'}>
       <input
         className={'flex mr-4'}
@@ -20,10 +19,6 @@ export const Checkbox: React.FC<CheckboxProps> = ({
         checked={value}
         onChange={onChange}
       />
-=======
-    <label>
-      <input type="checkbox" checked={value} onChange={onChange} />
->>>>>>> b0231a145e6fd9c3fffdd0011b7f3794502463c1
       {label}
     </label>
   );

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -1,13 +1,20 @@
 import React, { ChangeEventHandler } from 'react';
 
-interface CheckboxProps {label: string, value: boolean, onChange: ChangeEventHandler};
+interface CheckboxProps {
+  label: string;
+  value: boolean;
+  onChange: ChangeEventHandler;
+}
 
-export const Checkbox: React.FC<CheckboxProps> = ({label, value, onChange}: CheckboxProps) => {
-    return (
-        <label>
-            <input type="checkbox" checked={value} onChange={onChange} />
-            {label}
-        </label>
-    );
+export const Checkbox: React.FC<CheckboxProps> = ({
+  label,
+  value,
+  onChange,
+}: CheckboxProps) => {
+  return (
+    <label>
+      <input type="checkbox" checked={value} onChange={onChange} />
+      {label}
+    </label>
+  );
 };
-

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -12,8 +12,13 @@ export const Checkbox: React.FC<CheckboxProps> = ({
   onChange,
 }: CheckboxProps) => {
   return (
-    <label>
-      <input type="checkbox" checked={value} onChange={onChange} />
+    <label className={'flex justify-start'}>
+      <input
+        className={'flex mr-4'}
+        type="checkbox"
+        checked={value}
+        onChange={onChange}
+      />
       {label}
     </label>
   );

--- a/src/models/activity.model.ts
+++ b/src/models/activity.model.ts
@@ -1,4 +1,9 @@
-import { Activity, ActivityCategory as PrismaActivityCategory, SignificanceLevel, Semester as PrismaSemester } from ".prisma/client";
+import {
+  Activity,
+  ActivityCategory as PrismaActivityCategory,
+  SignificanceLevel,
+  Semester as PrismaSemester,
+} from '.prisma/client';
 
 export type ActivityCategory = PrismaActivityCategory; //'TEACHING' | 'RESEARCH' | 'SERVICE';
 export type ActivityWeight = SignificanceLevel; //'MAJOR' | 'SIGNIFICANT' | 'MINOR';
@@ -15,6 +20,7 @@ export type ActivityDto = Activity; /*{
     category: ActivityCategory;
     significance: ActivityWeight;
     isFavorite: boolean;
+    semesterOtherDescription?: string;
 };*/
 
 export type CreateActivityDto = Omit<Activity, 'id'>; /*{
@@ -27,6 +33,7 @@ export type CreateActivityDto = Omit<Activity, 'id'>; /*{
     category: ActivityCategory;
     significance: ActivityWeight;
     isFavorite: boolean;
+    semesterOtherDescription?: string;
 };*/
 
 export type UpdateActivityDto = Omit<Partial<ActivityDto>, 'semester'>; /*{
@@ -40,13 +47,17 @@ export type UpdateActivityDto = Omit<Partial<ActivityDto>, 'semester'>; /*{
   significance: ActivityWeight;
   isFavorite: boolean;
 };*/
-export const isActivityCategory = (category: String): category is ActivityCategory => { 
-    return ["TEACHING", "RESEARCH", "SERVICE"].includes(category as ActivityCategory);
-}
+export const isActivityCategory = (
+  category: String,
+): category is ActivityCategory => {
+  return ['TEACHING', 'RESEARCH', 'SERVICE'].includes(
+    category as ActivityCategory,
+  );
+};
 
 export const categoryLabels: Record<ActivityCategory, string> = {
-    TEACHING: 'Teaching',
-    RESEARCH:
-      'Creative Activity, Scholarship and Research/Professional Development',
-    SERVICE: 'Service',
-  };
+  TEACHING: 'Teaching',
+  RESEARCH:
+    'Creative Activity, Scholarship and Research/Professional Development',
+  SERVICE: 'Service',
+};

--- a/src/store/form.store.ts
+++ b/src/store/form.store.ts
@@ -20,6 +20,7 @@ export interface FormState {
   year: number | null;
   date: string;
   description: string;
+  otherDescription: string;
 }
 
 const initialState: FormState = {
@@ -31,6 +32,7 @@ const initialState: FormState = {
   year: null,
   date: '',
   description: '',
+  otherDescription: '',
 };
 
 export const formSlice = createSlice({
@@ -61,6 +63,9 @@ export const formSlice = createSlice({
     setDescription: (state, action: PayloadAction<string>) => {
       state.description = action.payload;
     },
+    setOtherDescription: (state, action: PayloadAction<string>) => {
+      state.otherDescription = action.payload;
+    },
     resetForm: (state) => {
       state.step = 'selection';
       state.activityName = null;
@@ -70,6 +75,7 @@ export const formSlice = createSlice({
       state.year = null;
       state.date = '';
       state.description = '';
+      state.otherDescription = '';
     },
   },
 });
@@ -83,6 +89,7 @@ export const {
   setYear,
   setDate,
   setDescription,
+  setOtherDescription,
   resetForm,
 } = formSlice.actions;
 
@@ -111,5 +118,8 @@ export const selectDate: Selector<RootState, string> = (state) =>
 
 export const selectDescription: Selector<RootState, string> = (state) =>
   state.form.description;
+
+export const selectOtherDescription: Selector<RootState, string> = (state) =>
+  state.form.otherDescription;
 
 export default formSlice.reducer;

--- a/src/store/form.store.ts
+++ b/src/store/form.store.ts
@@ -16,7 +16,7 @@ export interface FormState {
   activityName: string | null;
   category: ActivityCategory | null;
   weight: ActivityWeight | null;
-  semester: Semester | null;
+  semester: Semester[] | null;
   year: number | null;
   date: string;
   description: string;
@@ -49,7 +49,7 @@ export const formSlice = createSlice({
     setWeight: (state, action: PayloadAction<ActivityWeight>) => {
       state.weight = action.payload;
     },
-    setSemester: (state, action: PayloadAction<Semester>) => {
+    setSemester: (state, action: PayloadAction<Semester[]>) => {
       state.semester = action.payload;
     },
     setYear: (state, action: PayloadAction<number | null>) => {
@@ -100,7 +100,7 @@ export const selectWeight: Selector<RootState, ActivityWeight | null> = (
   state,
 ) => state.form.weight;
 
-export const selectSemester: Selector<RootState, Semester | null> = (state) =>
+export const selectSemester: Selector<RootState, Semester[] | null> = (state) =>
   state.form.semester;
 
 export const selectYear: Selector<RootState, number | null> = (state) =>


### PR DESCRIPTION
**Ticket:** https://github.com/orgs/sandboxnu/projects/9/views/1?pane=issue&itemId=22952790

**Frontend:**
Added checkboxes to activity submission page for semesters. Users can select multiple semesters to submit for their activity. And if Other is checked, users are required to enter a description for their activity submission.

**Backend:**
Modified Prisma schema for Activity to take in a description for the `other` checkbox.

**To run/test:**
Follow regular steps in README to manual test/see changes

**Images:**
**Form display:**
<img width="617" alt="image" src="https://user-images.githubusercontent.com/60594860/229313796-1bfb08bd-8279-43ae-9899-1e73cbcd5b4a.png">

**With Other checked:**
<img width="593" alt="image" src="https://user-images.githubusercontent.com/60594860/229313808-356e2c6a-d95d-42e5-a0e1-da1aff619efb.png">
