### PR TITLE
Persist SidebarBubble State to Cookies

### DIFF
--- a/src/components/ActivityForm/FormInstructions.tsx
+++ b/src/components/ActivityForm/FormInstructions.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 const FormInstructions: React.FC = () => {
   return (
     <>
-      <SideBarBubble title="Instructions ">
+      <SideBarBubble title="Instructions" cookieKey="form-instructions">
         <ul className="list-inside space-y-3 my-4">
           <li className="text-sm">
             For each activity, select a category, insert information about each

--- a/src/components/Profile/ProfileInstructions.tsx
+++ b/src/components/Profile/ProfileInstructions.tsx
@@ -1,30 +1,37 @@
+import SideBarBubble from '@/shared/components/SideBarBubble';
 import React from 'react';
 
 const ProfileInstructions: React.FC = () => {
   return (
     <>
-      <div className="flex flex-col px-5 py-4 bg-medium-grey w-full rounded-lg space-y-4">
-        <h3>Activity Distribution</h3>
-        <p>
-          The activity distribution section contains your status as a professor,
-          which relates to the expected amount of activities that the Merit
-          Committee will expect you to complete over the course of a year (not
-          academic year).
-        </p>
-        <p>
-          Please select the appropriate status from the drop-down menu. The
-          activity percentages between the three categories should total to
-          100%.
-        </p>
-      </div>
-      <div className="flex flex-col px-5 py-4 bg-medium-grey w-full rounded-lg space-y-4">
-        <h3>Contact Information</h3>
+      <SideBarBubble
+        title="Activity Distribution"
+        cookieKey="profile-activity-distribution"
+      >
+        <div className="my-2 space-y-1">
+          <p>
+            The activity distribution section contains your status as a
+            professor, which relates to the expected amount of activities that
+            the Merit Committee will expect you to complete over the course of a
+            year (not academic year).
+          </p>
+          <p>
+            Please select the appropriate status from the drop-down menu. The
+            activity percentages between the three categories should total to
+            100%.
+          </p>
+        </div>
+      </SideBarBubble>
+      <SideBarBubble
+        title="Contact Information"
+        cookieKey="profile-contact-information"
+      >
         <p>
           For the contact information in your profile, please enter your school
           phone number and office location, as well as your @northeastern.edu
           email.
         </p>
-      </div>
+      </SideBarBubble>
     </>
   );
 };

--- a/src/components/Submissions/SubmissionsInfo.tsx
+++ b/src/components/Submissions/SubmissionsInfo.tsx
@@ -28,23 +28,25 @@ const SubmissionsInfo: React.FC<SubmissionsInfoProps> = ({
     activitiesBySigLevel['SIGNIFICANT'].length;
   return (
     <>
-      <SideBarBubble title="Instructions">
+      <SideBarBubble title="Instructions" cookieKey="submissions-instructions">
         <div className="space-y-4 my-2">
           <p className="text-sm">
-            8-10 Major Activity: 2 and above + Significant and Minor Activities:
-            10 and above
+            8-10 Score: 2+ Major Activities, 10+ Significant and Minor
+            Activities
           </p>
           <p className="text-sm">
-            7-8 Major Activity: 1-2 + Significant and Minor Activities: 6-10{' '}
+            7-8 Score: 1-2 Major Activities, 6-10 Significant and Minor
+            Activities
           </p>
           <p className="text-sm">
-            6-7 Major Activity: 0-1 + Significant and Minor Activities: 2-6{' '}
+            6-7 Score: 0-1 Major Activities, 2-6 Significant and Minor
+            Activities
           </p>
           <p className="text-sm">6 Fulfilling required course load</p>
         </div>
       </SideBarBubble>
 
-      <SideBarBubble title="Summary">
+      <SideBarBubble title="Summary" cookieKey="submissions-summary">
         <>
           <div className="space-y-2 my-4">
             {Object.entries(activitiesBySigLevel).map(
@@ -72,7 +74,10 @@ const SubmissionsInfo: React.FC<SubmissionsInfoProps> = ({
           <p className="mt-6 mb-2">Total: {totalCount} activities</p>
         </>
       </SideBarBubble>
-      <SideBarBubble title="Narrative Preview">
+      <SideBarBubble
+        title="Narrative Preview"
+        cookieKey="submissions-narrative-preview"
+      >
         <p className="mt-2">
           {' '}
           {narrative?.text || 'No narrative submitted yet.'}{' '}

--- a/src/shared/components/SideBarBubble.tsx
+++ b/src/shared/components/SideBarBubble.tsx
@@ -1,16 +1,40 @@
 import Image from 'next/image';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
-const SideBarBubble: React.FC<{ title: string; children: JSX.Element }> = ({
-  title,
-  children,
-}) => {
-  const [dropDownOpen, setDropDownOpen] = useState(false);
+const SideBarBubble: React.FC<{
+  title: string;
+  cookieKey: string;
+  children: JSX.Element;
+}> = ({ title, cookieKey, children }) => {
+  const [dropDownOpen, setDropDownOpen] = useState(true);
+
+  const toggleDropDown = () => {
+    const newState = !dropDownOpen;
+    console.log(`SET sidebar-dropdown-${cookieKey} => ${newState}`);
+    window.localStorage.setItem(
+      `sidebar-dropdown-${cookieKey}`,
+      JSON.stringify(newState),
+    );
+    setDropDownOpen(newState);
+  };
+
+  useEffect(() => {
+    const storedDropDownCookie = JSON.parse(
+      window.localStorage.getItem(`sidebar-dropdown-${cookieKey}`) || 'null',
+    );
+    if (storedDropDownCookie !== null) {
+      console.log(
+        `GET sidebar-dropdown-${cookieKey} => ${storedDropDownCookie}`,
+      );
+      setDropDownOpen(storedDropDownCookie);
+    }
+  }, []);
+
   return (
     <div className="flex flex-col px-5 py-3 bg-medium-grey w-full rounded-lg shadow-sm">
       <div
         className="flex items-center space-x-4 cursor-pointer"
-        onClick={() => setDropDownOpen((b) => !b)}
+        onClick={toggleDropDown}
       >
         <Image
           className={dropDownOpen ? 'rotate-90' : ''}


### PR DESCRIPTION
Updated functionality for SidebarBubble: the bubbles initially are open, and each bubbles maintains its previous state after navigating to different pages or refreshing the page. The code uses cookies (window.localStorage) to store the state of each bubble.


https://user-images.githubusercontent.com/57200118/230514098-510b08df-082b-48ce-91d3-0e2d2a276485.mov

