### PR TITLE
Merit Committee Onboarding

### DIFF
--- a/src/components/AccountSetup/RoleSetup.tsx
+++ b/src/components/AccountSetup/RoleSetup.tsx
@@ -26,10 +26,11 @@ const RoleSetup: React.FC<RoleSetupProps> = () => {
     if (!codeInput) return setAccessCodeError('Please enter your access code.');
 
     const res = await obtainRoleForAccessCode(codeInput);
-    if (res === ResponseStatus.NotFound)
+    if (res === ResponseStatus.NotFound) {
       setAccessCodeError('Incorrect access code.');
-    else if (isErrorResponse(res)) return setError(responseStatusMessage[res]);
-    else {
+    } else if (isErrorResponse(res)) {
+      setError(responseStatusMessage[res]);
+    } else {
       dispatch(setRole(res));
       dispatch(setStep('user info'));
     }

--- a/src/components/AccountSetup/StepIndicator.tsx
+++ b/src/components/AccountSetup/StepIndicator.tsx
@@ -39,12 +39,12 @@ const StepLabel: React.FC<{ step: number; state: CompletionState }> = ({
   state,
 }) => (
   <p className={`text-sm font-semibold ${textCompletionClass[state]}`}>
-    {step + 1}
+    {step}
   </p>
 );
 
 const idempotentArray = (length: number): number[] =>
-  Array.apply(null, Array(length)).map((_, idx) => idx);
+  Array.apply(null, Array(length)).map((_, idx) => idx + 1);
 
 const StepIndicator: React.FC<StepIndicatorProps> = ({
   currentStep,

--- a/src/components/AccountSetup/StepWrapper.tsx
+++ b/src/components/AccountSetup/StepWrapper.tsx
@@ -7,6 +7,7 @@ import { selectFieldsIncomplete } from '@/store/accountSetup.store';
 interface StepWrapperProps {
   currentStep: number;
   numSteps?: number;
+  hideProgressBar?: boolean;
   title: string;
   subtitle: string;
   next: () => void;
@@ -16,7 +17,8 @@ interface StepWrapperProps {
 
 const StepWrapper: React.FC<StepWrapperProps> = ({
   currentStep,
-  numSteps = 3,
+  hideProgressBar = false,
+  numSteps = 2,
   title,
   subtitle,
   next,
@@ -27,18 +29,17 @@ const StepWrapper: React.FC<StepWrapperProps> = ({
 
   return (
     <div className="flex flex-col w-full items-center rounded-lg bg-gray-100 shadow-lg pt-6 px-20 pb-11">
-      <StepIndicator currentStep={currentStep} numSteps={numSteps} />
-      <div className="my-8 flex flex-col items-center">
+      {!hideProgressBar && (
+        <StepIndicator currentStep={currentStep} numSteps={numSteps} />
+      )}
+      <div className="mt-6 mb-4 flex flex-col items-center">
         <p className="text-2xl font-bold">{title}</p>
         <p className="text-sm font-medium">{subtitle}</p>
       </div>
       {children}
       <div className="flex justify-between mt-12 w-full" id="buttons">
         {currentStep > 0 && (
-          <Button
-            variant='secondary'
-            onClick={back}
-          >
+          <Button variant="secondary" onClick={back}>
             <p className="text-xs">Back</p>
           </Button>
         )}

--- a/src/shared/components/DropdownInput.tsx
+++ b/src/shared/components/DropdownInput.tsx
@@ -35,7 +35,12 @@ const DropdownInput = <T extends unknown>({
     : options;
 
   return (
-    <div className="relative w-full min-h-[40px] z-[2]">
+    <div
+      className={clsx([
+        'relative w-full min-h-[40px]',
+        absoluteDropdown && 'z-[2]',
+      ])}
+    >
       <div
         className={clsx([
           'flex flex-col bg-white border-[0.5px] border-gray-500 rounded-lg cursor-pointer',

--- a/src/shared/components/DropdownInput.tsx
+++ b/src/shared/components/DropdownInput.tsx
@@ -35,7 +35,7 @@ const DropdownInput = <T extends unknown>({
     : options;
 
   return (
-    <div className="relative w-full min-h-[40px]">
+    <div className="relative w-full min-h-[40px] z-[2]">
       <div
         className={clsx([
           'flex flex-col bg-white border-[0.5px] border-gray-500 rounded-lg cursor-pointer',

--- a/src/shared/utils/misc.util.ts
+++ b/src/shared/utils/misc.util.ts
@@ -1,3 +1,5 @@
+import { ResponseStatus } from '@/client/activities.client';
+
 export const toTitleCase = (str: string): string => {
   return str
     .split(' ')
@@ -29,4 +31,23 @@ export const shortenDescription = (description: string): string => {
   }
 
   return description.substring(0, 99) + '...';
+};
+
+export const isErrorResponse = (
+  status: ResponseStatus | any,
+): status is ResponseStatus => {
+  return [
+    ResponseStatus.BadRequest,
+    ResponseStatus.NotFound,
+    ResponseStatus.Unauthorized,
+    ResponseStatus.UnknownError,
+  ].includes(status);
+};
+
+export const responseStatusMessage: Record<ResponseStatus, string> = {
+  [ResponseStatus.Success]: 'Success',
+  [ResponseStatus.UnknownError]: 'Unknown Error',
+  [ResponseStatus.NotFound]: 'Not Found',
+  [ResponseStatus.Unauthorized]: 'Unauthorized',
+  [ResponseStatus.BadRequest]: 'Bad Request',
 };

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -59,6 +59,7 @@
   top: 150%;
   left: 50%;
   margin-left: -70px;
+  pointer-events: none;
 }
 
 .infoTooltip .infoTooltipText::before,


### PR DESCRIPTION
Closes #70 

## Description

Creates a separate onboarding for for non-faculty members that does not have the additional step for specifying ProfessorInfo.

## Things you especially want reviewed

Confirm with designers that we only want two steps for faculty onboarding.
Also are we fine creating a mock ProfessorInfo for merit committee members (`createMeritInfo`)? Or would we rather just create a User and no ProfessorInfo.


## Screenshots if Applicable

**Role Setup:**
<img width="1439" alt="onboarding role" src="https://github.com/sandboxnu/faculty-activity-tracker/assets/57200118/254f7d0f-3045-4564-bacd-14e377841d0d">

**Non-Faculty Screen:**
<img width="1438" alt="onboarding nonfaculty" src="https://github.com/sandboxnu/faculty-activity-tracker/assets/57200118/eed88422-aaf8-4f78-8581-bedcf9a49d4b">

**Faculty Screens:** 
<img width="1440" alt="onboarding faculty 1" src="https://github.com/sandboxnu/faculty-activity-tracker/assets/57200118/b8cd3cdf-8ff2-4066-b32d-39377cd8305c">

<img width="1440" alt="onboarding faculty 2" src="https://github.com/sandboxnu/faculty-activity-tracker/assets/57200118/7cc833a5-8530-439d-8b9b-0ac391751055">

## Checklist

- [x] Ticket number in PR title
- [x] Add ticket number to ("Closes #")
- [x] Move status to Code Review in GH Board
- [x] People added to reviewers
- [ ] Asked for Review in Slack
