### PR TITLE
Create a singleton Prisma instance and store it in `globalThis` object

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,0 +1,17 @@
+import { PrismaClient } from '@prisma/client';
+
+const prismaClientSingleton = () => {
+  return new PrismaClient();
+};
+
+type PrismaClientSingleton = ReturnType<typeof prismaClientSingleton>;
+
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClientSingleton | undefined;
+};
+
+const prisma = globalForPrisma.prisma ?? prismaClientSingleton();
+
+export default prisma;
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,9 +1,7 @@
 // prisma/seed.ts
 
-import { PrismaClient, Role, SabbaticalOption, Semester } from '@prisma/client';
-
-// initialize Prisma Client
-const prisma = new PrismaClient();
+import { Role, SabbaticalOption } from '@prisma/client';
+import prisma from 'lib/db';
 
 async function createUserData() {
   const user1 = await prisma.user.upsert({

--- a/src/pages/api/test.ts
+++ b/src/pages/api/test.ts
@@ -1,8 +1,6 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { PrismaClient } from '.prisma/client';
-
-const prisma = new PrismaClient();
+import prisma from 'lib/db';
 
 export default async function handler(
   req: NextApiRequest,

--- a/src/services/accessCode.ts
+++ b/src/services/accessCode.ts
@@ -1,6 +1,5 @@
-import { PrismaClient, Role } from '.prisma/client';
-
-const prisma = new PrismaClient();
+import { Role } from '.prisma/client';
+import prisma from 'lib/db';
 
 export const obtainRole = async (accessCode: string): Promise<Role | null> => {
   const roleAccessCode = await prisma.roleAccessCode.findFirst({

--- a/src/services/activity.ts
+++ b/src/services/activity.ts
@@ -1,11 +1,10 @@
-import { PrismaClient, Activity } from '.prisma/client';
+import { Activity } from '.prisma/client';
 import {
   ActivityOrderByQuery,
   CreateActivityDto,
   UpdateActivityDto,
 } from '@/models/activity.model';
-
-const prisma = new PrismaClient();
+import prisma from 'lib/db';
 
 export const getAllActivities = async (): Promise<Activity[]> => {
   const activities = await prisma.activity.findMany();

--- a/src/services/narrative.ts
+++ b/src/services/narrative.ts
@@ -1,12 +1,11 @@
-import { PrismaClient, Narrative } from '.prisma/client';
+import { Narrative } from '.prisma/client';
 import {
   CreateNarrativeDto,
   UpdateNarrativeDto,
   DeleteNarrativeDto,
 } from '@/models/narrative.model';
 import { NarrativeCategory } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import prisma from 'lib/db';
 
 export const getNarrativeForUserForCategory = async (
   userId: number,

--- a/src/services/professorInfo.ts
+++ b/src/services/professorInfo.ts
@@ -1,10 +1,9 @@
-import { PrismaClient, ProfessorInfo, SabbaticalOption } from '.prisma/client';
+import { ProfessorInfo, SabbaticalOption } from '.prisma/client';
 import {
   CreateProfessorInfoDto,
   UpdateProfessorInfoDto,
 } from '@/models/professorInfo.model';
-
-const prisma = new PrismaClient();
+import prisma from 'lib/db';
 
 export const getProfessorInfoForUser = async (
   userId: number,

--- a/src/services/professorScore.ts
+++ b/src/services/professorScore.ts
@@ -1,7 +1,6 @@
 import { UpdateProfessorScoreDto } from '@/models/professorScore.model';
-import { PrismaClient, ProfessorScore } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import { ProfessorScore } from '@prisma/client';
+import prisma from 'lib/db';
 
 export const getProfessorScore = async (userId: number) => {
   const score = await prisma.professorScore.findUnique({

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, User } from '.prisma/client';
+import { User } from '.prisma/client';
 import {
   CreateUserDto,
   UpdateUserDto,
@@ -7,8 +7,7 @@ import {
   UserWithAllData,
   UserWithInfo,
 } from '@/models/user.model';
-
-const prisma = new PrismaClient();
+import prisma from 'lib/db';
 
 export const getAllUsers = async (): Promise<User[]> => {
   const users = await prisma.user.findMany();


### PR DESCRIPTION
Closes #85 

## Description

- Replaced all instances of `PrismaClient` with a single global instance
  - See `lib/db.ts`

## Things you especially want reviewed
- Check if all instances of `PrismaClient` are removed correctly

## Screenshots if Applicable

## Checklist

- [x] Ticket number in PR title
- [x] Add ticket number to ("Closes #")
- [x] Move status to Code Review in GH Board
- [x] People added to reviewers
- [x] Asked for Review in Slack
