### PR TITLE
Activity Submission Page Cleanup

### DIFF
--- a/src/components/AccountSetup/RoleSetup.tsx
+++ b/src/components/AccountSetup/RoleSetup.tsx
@@ -56,7 +56,7 @@ const RoleSetup: React.FC<RoleSetupProps> = () => {
             labelClass="text-body"
             incomplete={!!accessCodeError}
             incompleteMessage={accessCodeError}
-            infoMessage="Your access code can be found in your Northeastern email. If not, please contact Mark Sivak."
+            tooltipMessage="Your access code can be found in your Northeastern email. If not, please contact Mark Sivak."
             withMarginY={false}
             required
           >

--- a/src/components/ActivityForm/FormInput.tsx
+++ b/src/components/ActivityForm/FormInput.tsx
@@ -240,7 +240,7 @@ const FormInput: React.FC<FormInputProps> = ({ isEditing }) => {
         incompleteMessage={weightError}
         tooltipMessage={[
           'Major: New courses, significantly redesigned courses, large courses (more than 25 students), running a dialogue',
-          'Significant: Workshops, fieldtrips, collaborations, client projects, etc.',
+          'Significant: Workshops, field trips, collaborations, client projects, etc.',
           'Minor: Directed study, guest critic, guest lecture, letter of recommendation, mentoring',
         ]}
         tooltipPosition="right"

--- a/src/components/ActivityForm/FormInput.tsx
+++ b/src/components/ActivityForm/FormInput.tsx
@@ -65,7 +65,9 @@ const FormInput: React.FC<FormInputProps> = ({ isEditing }) => {
   const name: string | null = useSelector(selectName);
   const weight: ActivityWeight | null = useSelector(selectWeight);
   const semesters: Semester[] | null = useSelector(selectSemesters);
-  const checkedSemesters: Record<Semester, boolean> = useSelector(selectCheckedSemesters);
+  const checkedSemesters: Record<Semester, boolean> = useSelector(
+    selectCheckedSemesters,
+  );
   const otherChecked = checkedSemesters['OTHER'];
   const year: number | null = useSelector(selectYear);
   const description: string | null = useSelector(selectDescription);
@@ -79,9 +81,15 @@ const FormInput: React.FC<FormInputProps> = ({ isEditing }) => {
 
   const [nameError, setNameError] = useState<string | undefined>(undefined);
   const [weightError, setWeightError] = useState<string | undefined>(undefined);
-  const [semesterError, setSemesterError] = useState<string | undefined>(undefined);
-  const [descriptionError, setDescriptionError] = useState<string | undefined>(undefined);
-  const [otherDescriptionError, setOtherDescriptionError] = useState<string | undefined>(undefined);
+  const [semesterError, setSemesterError] = useState<string | undefined>(
+    undefined,
+  );
+  const [descriptionError, setDescriptionError] = useState<string | undefined>(
+    undefined,
+  );
+  const [otherDescriptionError, setOtherDescriptionError] = useState<
+    string | undefined
+  >(undefined);
 
   const semesterOptions: Option<Semester>[] = [
     { label: `Fall ${year}`, value: 'FALL' },
@@ -104,9 +112,9 @@ const FormInput: React.FC<FormInputProps> = ({ isEditing }) => {
 
   const onSemesterToggle = (semester: Semester) => {
     dispatch(
-      checkedSemesters[semester!] ?
-      removeSemester(semester!) :
-      addSemester(semester!)
+      checkedSemesters[semester!]
+        ? removeSemester(semester!)
+        : addSemester(semester!),
     );
     if (semesterError) setSemesterError(undefined);
   };
@@ -114,18 +122,18 @@ const FormInput: React.FC<FormInputProps> = ({ isEditing }) => {
   const onOtherDescriptionChange = (val: string) => {
     dispatch(setOtherDescription(val));
     if (otherDescriptionError) setOtherDescriptionError(undefined);
-  }
+  };
 
   const onDescriptionChange = (val: string) => {
     dispatch(setDescription(val));
     if (descriptionError) setDescriptionError(undefined);
-  }
+  };
 
   const displayOtherDescription = () => {
     return (
       <InputContainer
         label="If you checked Other, please explain in the area below."
-        labelClass='text-slate-600'
+        labelClass="text-slate-600"
         incomplete={!!otherDescriptionError}
         incompleteMessage={otherDescriptionError}
         withMarginY
@@ -136,25 +144,25 @@ const FormInput: React.FC<FormInputProps> = ({ isEditing }) => {
           change={onOtherDescriptionChange}
         />
       </InputContainer>
-    )
+    );
   };
 
   const validateFormData = (): ActivityFormData | undefined => {
     if (formData) return formData;
     if (!name) {
-      setNameError("Enter an activity name.");
+      setNameError('Enter an activity name.');
     }
     if (!weight) {
-      setWeightError("Select a weight.");
+      setWeightError('Select a weight.');
     }
     if (!semesters) {
-      setSemesterError("Select semesters.");
+      setSemesterError('Select semesters.');
     }
     if (otherChecked && !otherDescription) {
       setOtherDescriptionError("Enter 'Other' semester explanation.");
     }
     if (!description) {
-      setDescriptionError("Enter a description.");
+      setDescriptionError('Enter a description.');
     }
   };
 
@@ -254,11 +262,11 @@ const FormInput: React.FC<FormInputProps> = ({ isEditing }) => {
       >
         <div className="flex flex-col space-y-2">
           {semesterOptions.map(({ label, value: semester }) => (
-              <Checkbox
-                label={label}
-                key={`checkbox-${semester}`}
-                value={checkedSemesters[semester!]}
-                onChange={() => onSemesterToggle(semester!)}
+            <Checkbox
+              label={label}
+              key={`checkbox-${semester}`}
+              value={checkedSemesters[semester!]}
+              onChange={() => onSemesterToggle(semester!)}
             />
           ))}
         </div>

--- a/src/components/ActivityForm/FormInput.tsx
+++ b/src/components/ActivityForm/FormInput.tsx
@@ -1,25 +1,26 @@
-import React, { ChangeEventHandler, useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import moment from 'moment';
 import { useDispatch, useSelector } from 'react-redux';
 import {
+  addSemester,
+  removeSemester,
   selectActivityId,
   selectCategory,
-  selectDate,
+  selectCheckedSemesters,
   selectDescription,
+  selectActivityFormData,
   selectLastDateModified,
   selectName,
   selectOtherDescription,
-  selectSemester,
   selectWeight,
-  selectYear,
-  setDate,
   setDescription,
   setName,
   setOtherDescription,
-  setSemester,
   setStep,
   setWeight,
-  setYear,
+  selectYear,
+  ActivityFormData,
+  selectSemesters,
 } from '../../store/form.store';
 import {
   ActivityCategory,
@@ -29,53 +30,32 @@ import {
   Semester,
   UpdateActivityDto,
 } from '../../models/activity.model';
-import Tooltip from '../../shared/components/Tooltip';
 import {
   createActivity,
   ResponseStatus,
   updateActivityClient,
 } from '@/client/activities.client';
-import Image from 'next/image';
 import { useSession } from 'next-auth/react';
 import { Checkbox } from '@/shared/components/Checkbox';
 import { ErrorBanner } from '../ErrorBanner';
 import { useRouter } from 'next/router';
-import DropdownInput from '@/shared/components/DropdownInput';
+import DropdownInput, { Option } from '@/shared/components/DropdownInput';
 import InputContainer from '@/shared/components/InputContainer';
 import TextInput from '@/shared/components/TextInput';
 import TextAreaInput from '@/shared/components/TextAreaInput';
 import Button from '@/shared/components/Button';
 
-const weightOptions = [
+const weightOptions: Option<ActivityWeight>[] = [
   { label: 'Major', value: 'MAJOR' },
   { label: 'Significant', value: 'SIGNIFICANT' },
   { label: 'Minor', value: 'MINOR' },
 ];
 
-const WeightInfo = () => (
-  <div className="flex items-center space-x-2 text-gray-500">
-    <Image
-      src="/media/infoIcon.svg"
-      alt="Little information icon"
-      width={16}
-      height={16}
-    />
-    <Tooltip
-      tooltipTitle="Weight Examples"
-      text={[
-        'Major: New courses, significantly redesigned courses, large courses (more than 25 students), running a dialogue',
-        'Significant: Workshops, fieldtrips, collaborations, client projects, etc.',
-        'Minor: Directed study, guest critic, guest lecture, letter of recommendation, mentoring',
-      ]}
-    />
-  </div>
-);
-
 interface FormInputProps {
-  editing: boolean;
+  isEditing: boolean;
 }
 
-const FormInput: React.FC<FormInputProps> = (props: FormInputProps) => {
+const FormInput: React.FC<FormInputProps> = ({ isEditing }) => {
   const { data: session } = useSession();
   const router = useRouter();
 
@@ -84,127 +64,111 @@ const FormInput: React.FC<FormInputProps> = (props: FormInputProps) => {
   const category: ActivityCategory | null = useSelector(selectCategory);
   const name: string | null = useSelector(selectName);
   const weight: ActivityWeight | null = useSelector(selectWeight);
-  const semester: Semester[] | null = useSelector(selectSemester);
+  const semesters: Semester[] | null = useSelector(selectSemesters);
+  const checkedSemesters: Record<Semester, boolean> = useSelector(selectCheckedSemesters);
+  const otherChecked = checkedSemesters['OTHER'];
   const year: number | null = useSelector(selectYear);
-  const date: string = useSelector(selectDate);
-  const description: string = useSelector(selectDescription);
+  const description: string | null = useSelector(selectDescription);
   const otherDescription: string | null = useSelector(selectOtherDescription);
   const lastDateModified: bigint | null = useSelector(selectLastDateModified);
+  const formData = useSelector(selectActivityFormData);
 
-  const [checkFall, setCheckFall] = useState(false);
-  const [checkSpring, setCheckSpring] = useState(false);
-  const [checkSummer, setCheckSummer] = useState(false);
-  const [checkOther, setCheckOther] = useState(false);
-  const [isEditing, setEditingState] = useState(props.editing);
+  // TODO: replace with toast error
   const [showEditingError, toggleEditingError] = useState(false);
   const [errorText, setErrorText] = useState('');
 
+  const [nameError, setNameError] = useState<string | undefined>(undefined);
+  const [weightError, setWeightError] = useState<string | undefined>(undefined);
+  const [semesterError, setSemesterError] = useState<string | undefined>(undefined);
+  const [descriptionError, setDescriptionError] = useState<string | undefined>(undefined);
+  const [otherDescriptionError, setOtherDescriptionError] = useState<string | undefined>(undefined);
+
+  const semesterOptions: Option<Semester>[] = [
+    { label: `Fall ${year}`, value: 'FALL' },
+    { label: `Spring ${year}`, value: 'SPRING' },
+    { label: `Summer ${year}`, value: 'SUMMER' },
+    { label: 'Other', value: 'OTHER' },
+  ];
+
   const dispatch = useDispatch();
 
-  useEffect(() => {
-    if (!semester) return;
-    semester.forEach((sem: Semester) => {
-      switch (sem) {
-        case 'FALL':
-          setCheckFall(true);
-          break;
-        case 'SPRING':
-          setCheckSpring(true);
-          break;
-        case 'SUMMER':
-          setCheckSummer(true);
-          break;
-        case 'OTHER':
-          setCheckOther(true);
-          break;
-        default:
-          break;
-      }
-    });
-  }, [semester]);
-
-  const handleAddSemester: ChangeEventHandler<Element> = (event) => {
-    const newSemester: Semester = event.target.parentElement?.textContent
-      ?.trim()
-      .toLocaleUpperCase() as Semester;
-    if (semester) {
-      const added_semester = [...semester, newSemester];
-      dispatch(setSemester(added_semester));
-    } else {
-      dispatch(setSemester([newSemester]));
-    }
-    console.log('added' + semester);
+  const onNameChange = (val: string) => {
+    dispatch(setName(val));
+    if (nameError) setNameError(undefined);
   };
 
-  const handleRemoveSemester: ChangeEventHandler<Element> = (event) => {
-    const newSemester: Semester = event.target.parentElement?.textContent
-      ?.trim()
-      .toLocaleUpperCase() as Semester;
-
-    if (semester) {
-      const removed_semester = semester.filter((item) => item !== newSemester);
-      dispatch(setSemester(removed_semester));
-    }
-    console.log('removed' + semester);
+  const onWeightChange = (val: ActivityWeight | undefined) => {
+    dispatch(setWeight(val as ActivityWeight));
+    if (weightError) setWeightError(undefined);
   };
 
-  const handleYearChange = (val: string) => {
-    // delete entire input => reset year
-    if (val === '') {
-      dispatch(setYear(null));
-    } else {
-      const newYear: number = parseInt(val);
-      if (!isNaN(newYear)) {
-        dispatch(setYear(newYear));
-      }
-    }
+  const onSemesterToggle = (semester: Semester) => {
+    dispatch(
+      checkedSemesters[semester!] ?
+      removeSemester(semester!) :
+      addSemester(semester!)
+    );
+    if (semesterError) setSemesterError(undefined);
   };
+
+  const onOtherDescriptionChange = (val: string) => {
+    dispatch(setOtherDescription(val));
+    if (otherDescriptionError) setOtherDescriptionError(undefined);
+  }
+
+  const onDescriptionChange = (val: string) => {
+    dispatch(setDescription(val));
+    if (descriptionError) setDescriptionError(undefined);
+  }
 
   const displayOtherDescription = () => {
     return (
-      <div className={inputContainer}>
-        <div className={inputWrapper}>
-          <p className={'text-slate-600'}>
-            If you checked Other, please explain in the area below.
-          </p>
-          <div className={inputStatus + ' ml-auto'}></div>
-        </div>
+      <InputContainer
+        label="If you checked Other, please explain in the area below."
+        labelClass='text-slate-600'
+        incomplete={!!otherDescriptionError}
+        incompleteMessage={otherDescriptionError}
+        withMarginY
+      >
         <TextAreaInput
           value={otherDescription || ''}
-          change={(val) => dispatch(setOtherDescription(val))}
+          fillContainer
+          change={onOtherDescriptionChange}
         />
-      </div>
-    );
+      </InputContainer>
+    )
+  };
+
+  const validateFormData = (): ActivityFormData | undefined => {
+    if (formData) return formData;
+    if (!name) {
+      setNameError("Enter an activity name.");
+    }
+    if (!weight) {
+      setWeightError("Select a weight.");
+    }
+    if (!semesters) {
+      setSemesterError("Select semesters.");
+    }
+    if (otherChecked && !otherDescription) {
+      setOtherDescriptionError("Enter 'Other' semester explanation.");
+    }
+    if (!description) {
+      setDescriptionError("Enter a description.");
+    }
   };
 
   const submitActivity = () => {
-    if (
-      !description ||
-      !category ||
-      !weight ||
-      !name ||
-      !semester ||
-      !year ||
-      (!checkFall && !checkOther && !checkSpring && !checkSummer) ||
-      (checkOther && !otherDescription)
-    )
-      return;
+    const activityFormData = validateFormData();
+    if (!activityFormData || !userId) return;
 
     const newActivityDto: CreateActivityDto = {
-      userId: userId || 1,
-      semester: semester,
-      year: year,
-      //date : dateObject ? dateObject.getTime() : undefined,
+      ...activityFormData,
+      userId,
       dateModified: BigInt(new Date().getTime()),
-      name: name,
-      description: description,
-      category: category,
-      significance: weight,
       isFavorite: false,
-      semesterOtherDescription: otherDescription,
       meritStatus: null,
     };
-    console.log(newActivityDto);
     dispatch(setStep('loading'));
     createActivity(newActivityDto).then((res) => {
       dispatch(setStep(res === ResponseStatus.Success ? 'success' : 'error'));
@@ -212,31 +176,14 @@ const FormInput: React.FC<FormInputProps> = (props: FormInputProps) => {
   };
 
   const updateActivity: VoidFunction = () => {
-    if (
-      !description ||
-      !category ||
-      !weight ||
-      !name ||
-      !semester ||
-      !year ||
-      (!checkFall && !checkOther && !checkSpring && !checkSummer) ||
-      (checkOther && !otherDescription) ||
-      !activityId
-    )
-      return;
+    const activityFormData = validateFormData();
+    if (!activityFormData || !activityId) return;
 
     const updateActivityDto: UpdateActivityDto = {
+      ...activityFormData,
       id: activityId,
-      userId: userId,
-      semester: semester,
-      year: year,
+      userId,
       dateModified: BigInt(new Date().getTime()),
-      name: name,
-      description: description,
-      category: category,
-      significance: weight,
-      isFavorite: true,
-      semesterOtherDescription: otherDescription,
     };
     updateActivityClient(updateActivityDto).then((res) => {
       if (res === ResponseStatus.Success) {
@@ -252,10 +199,6 @@ const FormInput: React.FC<FormInputProps> = (props: FormInputProps) => {
   };
 
   if (category === null) return <div>Category must be selected</div>;
-
-  const inputContainer = 'flex flex-col my-2 space-y-1';
-  const inputWrapper = 'flex items-center';
-  const inputStatus = 'flex items-center py-3';
 
   return (
     <div className="flex flex-col">
@@ -273,21 +216,26 @@ const FormInput: React.FC<FormInputProps> = (props: FormInputProps) => {
       )}
       <InputContainer
         label="Name: "
-        incomplete={!name}
-        incompleteMessage="Enter an activity name."
+        incomplete={!!nameError}
+        incompleteMessage={nameError}
         withMarginY
       >
         <TextInput
           value={name || ''}
-          change={(val) => dispatch(setName(val))}
+          change={onNameChange}
           placeholder="Enter Activity Name"
         />
       </InputContainer>
-      <WeightInfo />
       <InputContainer
         label="Weight: "
-        incomplete={!weight}
-        incompleteMessage="Select a weight."
+        incomplete={!!weightError}
+        incompleteMessage={weightError}
+        tooltipMessage={[
+          'Major: New courses, significantly redesigned courses, large courses (more than 25 students), running a dialogue',
+          'Significant: Workshops, fieldtrips, collaborations, client projects, etc.',
+          'Minor: Directed study, guest critic, guest lecture, letter of recommendation, mentoring',
+        ]}
+        tooltipPosition="right"
         withMarginY
       >
         <DropdownInput
@@ -295,81 +243,37 @@ const FormInput: React.FC<FormInputProps> = (props: FormInputProps) => {
           placeholder="Select Weight"
           addOnClass="w-[175px]"
           initialValue={weightOptions.find((o) => o.value === weight)}
-          selectValue={(value) => dispatch(setWeight(value as ActivityWeight))}
-        />
-      </InputContainer>
-      <InputContainer
-        label="Year: "
-        incomplete={!year}
-        incompleteMessage="Enter a year."
-        withMarginY
-      >
-        <TextInput
-          value={year || ''}
-          change={(val) => handleYearChange(val)}
-          placeholder="Enter Year"
+          selectValue={onWeightChange}
         />
       </InputContainer>
       <InputContainer
         label="Semester: "
-        incomplete={!checkFall && !checkSpring && !checkOther && !checkSummer}
-        incompleteMessage="Select semesters."
+        incomplete={!!semesterError}
+        incompleteMessage={semesterError}
         withMarginY
       >
         <div className="flex flex-col space-y-2">
-          <Checkbox
-            label="Fall"
-            value={checkFall}
-            onChange={(event) => {
-              setCheckFall(!checkFall);
-              checkFall
-                ? handleRemoveSemester(event)
-                : handleAddSemester(event);
-            }}
-          />
-          <Checkbox
-            label="Spring"
-            value={checkSpring}
-            onChange={(event) => {
-              setCheckSpring(!checkSpring);
-              checkSpring
-                ? handleRemoveSemester(event)
-                : handleAddSemester(event);
-            }}
-          />
-          <Checkbox
-            label="Summer"
-            value={checkSummer}
-            onChange={(event) => {
-              setCheckSummer(!checkSummer);
-              checkSummer
-                ? handleRemoveSemester(event)
-                : handleAddSemester(event);
-            }}
-          />
-          <Checkbox
-            label="Other"
-            value={checkOther}
-            onChange={(event) => {
-              setCheckOther(!checkOther);
-              checkOther
-                ? handleRemoveSemester(event)
-                : handleAddSemester(event);
-            }}
-          />
+          {semesterOptions.map(({ label, value: semester }) => (
+              <Checkbox
+                label={label}
+                key={`checkbox-${semester}`}
+                value={checkedSemesters[semester!]}
+                onChange={() => onSemesterToggle(semester!)}
+            />
+          ))}
         </div>
       </InputContainer>
-      {checkOther ? displayOtherDescription() : ''}
+      {otherChecked ? displayOtherDescription() : ''}
       <InputContainer
         label="Description: "
-        incomplete={!description}
-        incompleteMessage="Enter a description."
+        incomplete={!!descriptionError}
+        incompleteMessage={descriptionError}
         withMarginY
       >
         <TextAreaInput
           value={description || ''}
           placeholder="Enter Description"
-          change={(val) => dispatch(setDescription(val))}
+          change={onDescriptionChange}
           addOnClass="w-full"
         />
       </InputContainer>
@@ -382,17 +286,7 @@ const FormInput: React.FC<FormInputProps> = (props: FormInputProps) => {
         >
           Back
         </Button>
-        <Button
-          disabled={
-            weight === null ||
-            date === null ||
-            description === '' ||
-            !semester ||
-            !name ||
-            (checkOther && !otherDescription)
-          }
-          onClick={isEditing ? updateActivity : submitActivity}
-        >
+        <Button onClick={isEditing ? updateActivity : submitActivity}>
           Submit
         </Button>
       </div>

--- a/src/components/Submissions/ActivityCarousel.tsx
+++ b/src/components/Submissions/ActivityCarousel.tsx
@@ -12,7 +12,7 @@ import {
   setLastDateModified,
   setName,
   setOtherDescription,
-  setSemester,
+  setSemesters,
   setWeight,
   setYear,
 } from '@/store/form.store';
@@ -76,13 +76,12 @@ const ActivityCarousel: React.FC<ActivityCarouselProps> = ({
     event: React.MouseEvent<HTMLDivElement, MouseEvent>,
     activity: ActivityDto,
   ) => {
-    // console.log(activity.dateModified);
     dispatch(setCategory(activity.category));
     dispatch(setActivityId(activity.id));
     dispatch(setName(activity.name));
     dispatch(setWeight(activity.significance));
     dispatch(setYear(activity.year));
-    dispatch(setSemester(activity.semester));
+    dispatch(setSemesters(activity.semester));
     dispatch(setDescription(activity.description));
     dispatch(setOtherDescription(activity.semesterOtherDescription));
     dispatch(setLastDateModified(activity.dateModified));

--- a/src/pages/playground/inputs.tsx
+++ b/src/pages/playground/inputs.tsx
@@ -72,7 +72,7 @@ const TextInputPlayground: React.FC = () => {
                 required={required}
                 incomplete={incomplete}
                 incompleteMessage="Incomplete message"
-                infoMessage={showTooltip ? 'Tooltip message' : ''}
+                tooltipMessage={showTooltip ? 'Tooltip message' : ''}
                 withMarginY={withMarginY}
               >
                 <TextInput

--- a/src/pages/submissions/[category].tsx
+++ b/src/pages/submissions/[category].tsx
@@ -6,7 +6,13 @@ import {
   seperateActivitiesBySignifanceLevel,
 } from '@/shared/utils/activity.util';
 import { bigintToJSON, toTitleCase } from '@/shared/utils/misc.util';
-import { resetForm, setWeight, setStep, setCategory, setYear } from '@/store/form.store';
+import {
+  resetForm,
+  setWeight,
+  setStep,
+  setCategory,
+  setYear,
+} from '@/store/form.store';
 import { ActivityCategory, SignificanceLevel } from '@prisma/client';
 import { GetServerSideProps } from 'next';
 import { getSession } from 'next-auth/react';
@@ -77,7 +83,7 @@ const SubmissionsPage: React.FC<SubmissionsPageProps> = ({
     );
     dispatch(setWeight(sigLevel));
     dispatch(setStep('form'));
-    dispatch(setYear((new Date()).getFullYear()));
+    dispatch(setYear(new Date().getFullYear()));
     router.push('/submissions/new');
   };
 

--- a/src/pages/submissions/[category].tsx
+++ b/src/pages/submissions/[category].tsx
@@ -6,7 +6,7 @@ import {
   seperateActivitiesBySignifanceLevel,
 } from '@/shared/utils/activity.util';
 import { bigintToJSON, toTitleCase } from '@/shared/utils/misc.util';
-import { resetForm, setWeight, setStep, setCategory } from '@/store/form.store';
+import { resetForm, setWeight, setStep, setCategory, setYear } from '@/store/form.store';
 import { ActivityCategory, SignificanceLevel } from '@prisma/client';
 import { GetServerSideProps } from 'next';
 import { getSession } from 'next-auth/react';
@@ -77,6 +77,7 @@ const SubmissionsPage: React.FC<SubmissionsPageProps> = ({
     );
     dispatch(setWeight(sigLevel));
     dispatch(setStep('form'));
+    dispatch(setYear((new Date()).getFullYear()));
     router.push('/submissions/new');
   };
 

--- a/src/pages/submissions/edit.tsx
+++ b/src/pages/submissions/edit.tsx
@@ -2,8 +2,6 @@ import FormContainer from '@/components/ActivityForm/FormContainer';
 import FormInput from '@/components/ActivityForm/FormInput';
 import Head from 'next/head';
 import React, { useEffect } from 'react';
-import { useSelector } from 'react-redux';
-//import './ActivityForm.css';
 
 const EditActivityForm: React.FunctionComponent = (props) => {
   useEffect(() => {
@@ -18,7 +16,7 @@ const EditActivityForm: React.FunctionComponent = (props) => {
         <title>Edit Submission</title>
       </Head>
       <FormContainer>
-        <FormInput editing={true} />
+        <FormInput isEditing={true} />
       </FormContainer>
     </>
   );

--- a/src/pages/submissions/new.tsx
+++ b/src/pages/submissions/new.tsx
@@ -4,19 +4,18 @@ import FormInput from '@/components/ActivityForm/FormInput';
 import ResultPage from '@/components/ActivityForm/ResultPage';
 import { FormStep, selectStep } from '@/store/form.store';
 import Head from 'next/head';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useSelector } from 'react-redux';
-//import './ActivityForm.css';
 
 const StepComponent: Record<FormStep, JSX.Element> = {
   selection: (
     <FormContainer>
       <CategorySelector />
     </FormContainer>
-  ), // TODO: Look into children
+  ),
   form: (
     <FormContainer>
-      <FormInput editing={false} />
+      <FormInput isEditing={false} />
     </FormContainer>
   ),
   success: <ResultPage success={true} />,

--- a/src/shared/components/InfoTooltip.tsx
+++ b/src/shared/components/InfoTooltip.tsx
@@ -2,14 +2,17 @@ import Image from 'next/image';
 import React from 'react';
 import { toTitleCase } from '../utils/misc.util';
 
-export type TooltipPosition = "bottom" | "right";
+export type TooltipPosition = 'bottom' | 'right';
 
 interface InfoTooltipProps {
   text: string[];
   tooltipPosition?: TooltipPosition;
 }
 
-const InfoTooltip: React.FC<InfoTooltipProps> = ({ text, tooltipPosition = "bottom" }) => {
+const InfoTooltip: React.FC<InfoTooltipProps> = ({
+  text,
+  tooltipPosition = 'bottom',
+}) => {
   return (
     <div className={`infoTooltip infoTooltip${toTitleCase(tooltipPosition)}`}>
       <Image src="/media/infoIcon.svg" alt="i" width={16} height={16} />

--- a/src/shared/components/InfoTooltip.tsx
+++ b/src/shared/components/InfoTooltip.tsx
@@ -1,13 +1,17 @@
 import Image from 'next/image';
 import React from 'react';
+import { toTitleCase } from '../utils/misc.util';
+
+export type TooltipPosition = "bottom" | "right";
 
 interface InfoTooltipProps {
   text: string[];
+  tooltipPosition?: TooltipPosition;
 }
 
-const InfoTooltip: React.FC<InfoTooltipProps> = ({ text }) => {
+const InfoTooltip: React.FC<InfoTooltipProps> = ({ text, tooltipPosition = "bottom" }) => {
   return (
-    <div className="infoTooltip">
+    <div className={`infoTooltip infoTooltip${toTitleCase(tooltipPosition)}`}>
       <Image src="/media/infoIcon.svg" alt="i" width={16} height={16} />
       <span className="infoTooltipText">
         {text.map((item) => {

--- a/src/shared/components/InfoTooltip.tsx
+++ b/src/shared/components/InfoTooltip.tsx
@@ -16,7 +16,7 @@ const InfoTooltip: React.FC<InfoTooltipProps> = ({
   return (
     <div className={`infoTooltip infoTooltip${toTitleCase(tooltipPosition)}`}>
       <Image src="/media/infoIcon.svg" alt="i" width={16} height={16} />
-      <span className="infoTooltipText">
+      <span className="infoTooltipText space-y-2">
         {text.map((item) => {
           return (
             <p key={item} className="text-tooltip">

--- a/src/shared/components/InputContainer.tsx
+++ b/src/shared/components/InputContainer.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image';
 import React from 'react';
-import InfoTooltip from './InfoTooltip';
+import InfoTooltip, { TooltipPosition } from './InfoTooltip';
 
 type InputContainerProps = {
   label: string;
@@ -8,7 +8,8 @@ type InputContainerProps = {
   required?: boolean; // whether the field is required
   incomplete?: boolean; // whether the field is currently incomplete or incorrect
   incompleteMessage?: string; // message to display when incomplete
-  infoMessage?: string; // any additional info to provide on hover
+  tooltipMessage?: string | string[]; // any additional info to provide on hover
+  tooltipPosition?: TooltipPosition;
   withMarginY?: boolean; // whether to include vertical margin
   children: JSX.Element;
 };
@@ -24,7 +25,8 @@ const InputContainer: React.FC<InputContainerProps> = ({
   required = false,
   incomplete = false,
   incompleteMessage,
-  infoMessage,
+  tooltipMessage,
+  tooltipPosition,
   withMarginY = false,
   children,
 }) => {
@@ -46,7 +48,12 @@ const InputContainer: React.FC<InputContainerProps> = ({
       <div className="flex items-center space-x-1">
         <p className={labelClass}>{label}</p>
         {required && <p className="text-lg text-red-500">*</p>}
-        {infoMessage && <InfoTooltip text={[infoMessage]} />}
+        {tooltipMessage && (
+          <InfoTooltip
+            text={Array.isArray(tooltipMessage) ? tooltipMessage : [tooltipMessage]}
+            tooltipPosition={tooltipPosition}
+          />
+        )}
       </div>
       <div
         data-input-status={incomplete ? 'error' : 'success'}

--- a/src/shared/components/InputContainer.tsx
+++ b/src/shared/components/InputContainer.tsx
@@ -50,7 +50,9 @@ const InputContainer: React.FC<InputContainerProps> = ({
         {required && <p className="text-lg text-red-500">*</p>}
         {tooltipMessage && (
           <InfoTooltip
-            text={Array.isArray(tooltipMessage) ? tooltipMessage : [tooltipMessage]}
+            text={
+              Array.isArray(tooltipMessage) ? tooltipMessage : [tooltipMessage]
+            }
             tooltipPosition={tooltipPosition}
           />
         )}

--- a/src/store/form.store.ts
+++ b/src/store/form.store.ts
@@ -27,7 +27,10 @@ export interface FormState {
 }
 
 // data to be provided when creating/updating activity
-export type ActivityFormData = Omit<CreateActivityDto, 'userId' | 'dateModified' | 'isFavorite' | 'meritStatus'>;
+export type ActivityFormData = Omit<
+  CreateActivityDto,
+  'userId' | 'dateModified' | 'isFavorite' | 'meritStatus'
+>;
 
 const initialState: FormState = {
   step: 'selection',
@@ -36,7 +39,7 @@ const initialState: FormState = {
   category: null,
   weight: null,
   semesters: null,
-  year: (new Date()).getFullYear(),
+  year: new Date().getFullYear(),
   date: '',
   description: null,
   otherDescription: null,
@@ -63,10 +66,13 @@ export const formSlice = createSlice({
       state.semesters = action.payload;
     },
     addSemester: (state, action: PayloadAction<Semester>) => {
-      state.semesters = Array.from(new Set([...(state.semesters || []), action.payload]));
+      state.semesters = Array.from(
+        new Set([...(state.semesters || []), action.payload]),
+      );
     },
     removeSemester: (state, action: PayloadAction<Semester>) => {
-      state.semesters = state.semesters?.filter(s => s !== action.payload) || null;
+      state.semesters =
+        state.semesters?.filter((s) => s !== action.payload) || null;
     },
     setYear: (state, action: PayloadAction<number | null>) => {
       state.year = action.payload;
@@ -92,7 +98,7 @@ export const formSlice = createSlice({
       state.category = null;
       state.weight = null;
       state.semesters = null;
-      state.year = (new Date()).getFullYear();
+      state.year = new Date().getFullYear();
       state.date = '';
       state.description = null;
       state.otherDescription = null;
@@ -133,17 +139,21 @@ export const selectWeight: Selector<RootState, ActivityWeight | null> = (
   state,
 ) => state.form.weight;
 
-export const selectSemesters: Selector<RootState, Semester[] | null> = (state) =>
-  state.form.semesters;
+export const selectSemesters: Selector<RootState, Semester[] | null> = (
+  state,
+) => state.form.semesters;
 
-export const selectCheckedSemesters: Selector<RootState, Record<Semester, boolean>> = (state) => {
+export const selectCheckedSemesters: Selector<
+  RootState,
+  Record<Semester, boolean>
+> = (state) => {
   const checkedSemesters: Record<Semester, boolean> = {
     FALL: false,
     SPRING: false,
     SUMMER: false,
-    OTHER: false
+    OTHER: false,
   };
-  state.form.semesters?.forEach(s => checkedSemesters[s] = true);
+  state.form.semesters?.forEach((s) => (checkedSemesters[s] = true));
   return checkedSemesters;
 };
 
@@ -167,7 +177,10 @@ export const selectLastDateModified: Selector<RootState, bigint | null> = (
   state,
 ) => state.form.lastDateModified;
 
-export const selectActivityFormData: Selector<RootState, ActivityFormData | null> = (state) => {
+export const selectActivityFormData: Selector<
+  RootState,
+  ActivityFormData | null
+> = (state) => {
   if (
     !state.form.activityName ||
     !state.form.description ||
@@ -175,7 +188,8 @@ export const selectActivityFormData: Selector<RootState, ActivityFormData | null
     !state.form.weight ||
     !state.form.semesters ||
     !state.form.year
-  ) return null;
+  )
+    return null;
   const otherChecked = state.form.semesters.includes('OTHER');
   if (otherChecked && !state.form.otherDescription) return null;
   return {
@@ -186,7 +200,7 @@ export const selectActivityFormData: Selector<RootState, ActivityFormData | null
     semester: state.form.semesters,
     semesterOtherDescription: state.form.otherDescription,
     year: state.form.year,
-  }
-}
+  };
+};
 
 export default formSlice.reducer;

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -69,7 +69,7 @@
 .infoTooltipRight .infoTooltipText {
   height: 100px;
   width: max-content;
-  max-width: 220px;
+  max-width: 280px;
   top: 50%;
   left: 150%;
   margin-top: -50px;
@@ -127,7 +127,7 @@
   border-bottom: 6px solid transparent;
   border-right: 6px solid white;
   margin-top: -6px;
-  margin-right: -2px;
+  margin-right: -0.5px;
   z-index: 1;
 }
 

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -56,21 +56,45 @@
   padding: 6px;
   position: absolute;
   z-index: 1;
+  pointer-events: none;
+}
+
+.infoTooltipBottom .infoTooltipText {
+  width: 140px;
   top: 150%;
   left: 50%;
   margin-left: -70px;
+}
+
+.infoTooltipRight .infoTooltipText {
+  height: 100px;
+  width: max-content;
+  max-width: 220px;
+  top: 50%;
+  left: 150%;
+  margin-top: -50px;
 }
 
 .infoTooltip .infoTooltipText::before,
 .infoTooltip .infoTooltipText::after {
   content: '';
   position: absolute;
+}
+
+.infoTooltipBottom .infoTooltipText::before,
+.infoTooltipBottom .infoTooltipText::after {
   bottom: 100%;
   left: 50%;
 }
 
-/* The outline of the triangle */
-.infoTooltip .infoTooltipText::before {
+.infoTooltipRight .infoTooltipText::before,
+.infoTooltipRight .infoTooltipText::after {
+  top: 50%;
+  right: 100%;
+}
+
+/* The outline of the up-pointing triangle */
+.infoTooltipBottom .infoTooltipText::before {
   border-left: 6.5px solid transparent;
   border-right: 6.5px solid transparent;
   border-bottom: 6.5px solid #585858;
@@ -78,13 +102,32 @@
   margin-bottom: 0px;
 }
 
-/* The white fill of the triangle */
-.infoTooltip .infoTooltipText::after {
+/* The white fill of the up-pointing triangle */
+.infoTooltipBottom .infoTooltipText::after {
   border-left: 6px solid transparent;
   border-right: 6px solid transparent;
   border-bottom: 6px solid white;
   margin-left: -6px;
   margin-top: -2px;
+  z-index: 1;
+}
+
+/* The outline of the left-pointing triangle */
+.infoTooltipRight .infoTooltipText::before {
+  border-top: 6.5px solid transparent;
+  border-bottom: 6.5px solid transparent;
+  border-right: 6.5px solid #585858;
+  margin-top: -6.5px;
+  margin-left: 0;
+}
+
+/* The white fill of the left-pointing triangle */
+.infoTooltipRight .infoTooltipText::after {
+  border-top: 6px solid transparent;
+  border-bottom: 6px solid transparent;
+  border-right: 6px solid white;
+  margin-top: -6px;
+  margin-right: -2px;
   z-index: 1;
 }
 


### PR DESCRIPTION
Closes #75 

## Description

Variety of cleanup to the Activity Submission page:
- replace "Weight Examples" tooltip with new tooltip, and modify `InfoTooltip` to allow messages on the right side
- remove "Year" input and automatically set year
- cleanup form logic with Redux
- update error logic: rather than displaying errors immediately and disabling Submit button, allows users to attempt submit then displays errors (same as user onboarding)

## Things you especially want reviewed

## Screenshots if Applicable

Before:
<img width="1440" alt="Screenshot 2023-11-05 at 12 59 51 PM" src="https://github.com/sandboxnu/faculty-activity-tracker/assets/57200118/e0d4ec11-fe2e-4714-a5a2-26cc9fab8d88">

Weight Tooltip:
<img width="1440" alt="weight tooltip" src="https://github.com/sandboxnu/faculty-activity-tracker/assets/57200118/c0170ffb-8247-4066-9618-2cd6e85a05e5">

Form Errors:
<img width="1440" alt="form errors" src="https://github.com/sandboxnu/faculty-activity-tracker/assets/57200118/d0af20fa-0e1b-4ea6-b618-dcdceeacd6a2">

Other Description Error (when Other checked but no description present):
<img width="1440" alt="other description error" src="https://github.com/sandboxnu/faculty-activity-tracker/assets/57200118/096b599a-3d6c-4d82-a9fe-737526cdc9d2">

## Checklist
- [x] Ticket number in PR title
- [x] Add ticket number to ("Closes #")
- [x] Move status to Code Review in GH Board
- [ ] People added to reviewers
- [ ] Asked for Review in Slack
