### PR TITLE
add *.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 .DS_Store
 *.pem
 /prisma/migrations
+*.lock
 
 # debug
 npm-debug.log*


### PR DESCRIPTION
## Description
Adds all .lock files to the gitignore
They should not be committed because they can interfere with the current GitHub actions workflow.

## Comments
If any new dependencies are added, this would require running "yarn" to update yarn.lock locally, as any changes to yarn.lock made by a merged pr that installed additional/updated packages would not be reflected in the remote.
