### PR TITLE
Make the Logo a hyperlink to return to the `/dashboard` page

### DIFF
--- a/src/shared/components/Header.tsx
+++ b/src/shared/components/Header.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/router';
 import Button from './Button';
+import Link from 'next/link';
 
 const Header: React.FC = () => {
   const { status } = useSession();
@@ -11,12 +12,17 @@ const Header: React.FC = () => {
 
   return (
     <div className="flex w-screen items-baseline bg-black px-5 py-3 font-bold">
-      <Image
-        src="/media/newLogo.svg"
-        alt="Faculty Activity Tracker Logo"
-        width={250}
-        height={70}
-      />
+      <Link href="/dashboard" passHref legacyBehavior>
+        <a>
+          <Image
+            src="/media/newLogo.svg"
+            alt="Faculty Activity Tracker Logo"
+            width={250}
+            height={70}
+            className="cursor-pointer"
+          />
+        </a>
+      </Link>
       {signedIn && (
         <Button
           onClick={() => router.push('/api/auth/signout')}


### PR DESCRIPTION
Closes #103 

## Description
- Made the logo a hyperlink to navigate back to the `/dashboard` page

## Things you especially want reviewed
- Check if it works as intended on all of the different pages where the `Header` is visible

## Screenshots if Applicable

## Checklist

- [x] Ticket number in PR title
- [x] Add ticket number to ("Closes #")
- [x] Move status to Code Review in GH Board
- [x] People added to reviewers
- [ ] Asked for Review in Slack
