### PR TITLE
implement front end for signing out (#100)

### DIFF
--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -54,6 +54,7 @@ const getPages = () => {
   if (process.env.VERCEL_ENV !== 'preview') {
     return {
       signIn: '/auth/signin',
+      signOut: '/auth/signout',
     };
   } else {
     return {};

--- a/src/pages/auth/signout.tsx
+++ b/src/pages/auth/signout.tsx
@@ -1,0 +1,41 @@
+import { signOut } from 'next-auth/react';
+import Button from '@/shared/components/Button';
+import { useRouter } from 'next/router'
+
+export default function SignOut() {
+  const router = useRouter();
+  return (
+    <div className="flex w-full flex-grow items-center justify-center">
+      <div className="flex-col items-center justify-center gap-3 rounded-lg bg-gray-100 px-10 py-7 shadow-lg">
+        <div className="text-center text-heading-1">
+          Sign out
+        </div>
+        <div className="text-center text-body py-4">
+          Are you sure you want to sign out?
+        </div>
+        <div className="flex justify-between gap-20 py-1">
+          <Button
+            variant="secondary"
+            onClick={() => {
+              router.back();
+            }}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={() => signOut({ callbackUrl: '/' })}
+          >
+            Yes, sign out
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export async function getServerSideProps() {
+  return {
+    props: { hideSidebars: true },
+  };
+}

--- a/src/pages/auth/signout.tsx
+++ b/src/pages/auth/signout.tsx
@@ -1,16 +1,14 @@
 import { signOut } from 'next-auth/react';
 import Button from '@/shared/components/Button';
-import { useRouter } from 'next/router'
+import { useRouter } from 'next/router';
 
 export default function SignOut() {
   const router = useRouter();
   return (
     <div className="flex w-full flex-grow items-center justify-center">
       <div className="flex-col items-center justify-center gap-3 rounded-lg bg-gray-100 px-10 py-7 shadow-lg">
-        <div className="text-center text-heading-1">
-          Sign out
-        </div>
-        <div className="text-center text-body py-4">
+        <div className="text-center text-heading-1">Sign out</div>
+        <div className="py-4 text-center text-body">
           Are you sure you want to sign out?
         </div>
         <div className="flex justify-between gap-20 py-1">
@@ -31,7 +29,7 @@ export default function SignOut() {
         </div>
       </div>
     </div>
-  )
+  );
 }
 
 export async function getServerSideProps() {


### PR DESCRIPTION
Closes #100

## Description

Added front end for sign out based on figma designs.
Cancel button returns user to the previous page, sign out runs the next auth process, bringing the user to a page where they can login again.

## Things you especially want reviewed

In dev, reloads page sometimes on first clicking it (afterwards shows signout frontend on first click), not sure if that's a my local machine issue. 

## Screenshots if Applicable

<img width="1366" alt="Screen Shot 2023-11-11 at 2 35 25 PM" src="https://github.com/sandboxnu/faculty-activity-tracker/assets/45926251/36772bab-749e-4df9-898b-42d17d06f673">

## Checklist

- [x] Ticket number in PR title
- [x] Add ticket number to ("Closes #")
- [x] Move status to Code Review in GH Board
- [x] People added to reviewers
- [ ] Asked for Review in Slack
