### PR TITLE
Protect `/merit` pages to only allow authenticated users

### DIFF
--- a/src/components/Profile/ProfileContainer.tsx
+++ b/src/components/Profile/ProfileContainer.tsx
@@ -20,6 +20,7 @@ import {
   isErrorResponse,
   responseStatusMessage,
 } from '@/shared/utils/misc.util';
+import ErrorMessage from '@/shared/components/ErrorMessage';
 
 interface ProfileContainerProps {
   userId: number;
@@ -74,12 +75,7 @@ const ProfileContainer: React.FC<ProfileContainerProps> = ({
     router.reload();
   };
 
-  if (error)
-    return (
-      <p className="mt-20 w-full text-center text-red-500">
-        Error: {error || 'unknown error.'}
-      </p>
-    );
+  if (error) return <ErrorMessage message={error} />;
 
   return (
     <div className="relative flex w-full flex-col pl-10">

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,6 +5,7 @@ export const config = {
     '/submissions',
     '/submissions/(.*)',
     '/narratives/(.*)',
+    '/merit/(.*)',
     '/profile',
     '/account-setup',
   ],

--- a/src/pages/admin.tsx
+++ b/src/pages/admin.tsx
@@ -23,6 +23,7 @@ import { bigintToJSON } from '@/shared/utils/misc.util';
 import Image from 'next/image';
 import Button from '@/shared/components/Button';
 import { getAccessCodes, setAccessCode } from '@/client/accessCodes.client';
+import ErrorMessage from '@/shared/components/ErrorMessage';
 
 interface AdminPageProps {
   users?: UserDto[];
@@ -38,7 +39,8 @@ export const getServerSideProps: GetServerSideProps<AdminPageProps> = async (
   if (!userId) return { props: { error: 'User not found' } };
 
   // if (user && !isAdminUser(user)) return { props: { error: 'bad role' } };
-  if (!session?.user?.admin) return { props: { error: 'bad role' } };
+  if (!session?.user?.admin)
+    return { props: { error: 'You are not authorized to view this page.' } };
 
   //const users: User[] = await getAllUsers();
   const users = await getUsersByQuery({}, { dateModified: 'desc' });
@@ -82,7 +84,7 @@ const AdminPage: React.FC<AdminPageProps> = ({
           if (facultyCodeObj) setFacultyAccessCode(facultyCodeObj.accessCode);
           if (meritCodeObj) setMeritAccessCode(meritCodeObj.accessCode);
         } else {
-          setError(response + '');
+          setError(initialError || response + '');
         }
       })
       .catch((error) => {
@@ -147,11 +149,7 @@ const AdminPage: React.FC<AdminPageProps> = ({
   }
 
   if (error || !users) {
-    return (
-      <p className="mt-20 w-full text-center text-red-500">
-        Error: {error || 'unknown error'}
-      </p>
-    );
+    return error ? <ErrorMessage message={error} /> : <ErrorMessage />;
   }
 
   const Header = () => (

--- a/src/pages/merit/dashboard.tsx
+++ b/src/pages/merit/dashboard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Unauthorized from '@/shared/components/Unauthorized';
 import { useSession } from 'next-auth/react';
 import Head from 'next/head';
+import ErrorMessage from '@/shared/components/ErrorMessage';
 
 const Dashboard: React.FC = () => {
   const { data: session, status } = useSession();
@@ -14,6 +15,10 @@ const Dashboard: React.FC = () => {
 
   if (status === 'unauthenticated') {
     return <Unauthorized />;
+  }
+
+  if (!session?.user.merit) {
+    return <ErrorMessage message="You are not authorized to view this page." />;
   }
 
   return (

--- a/src/pages/merit/graphs.tsx
+++ b/src/pages/merit/graphs.tsx
@@ -1,3 +1,6 @@
+import ErrorMessage from '@/shared/components/ErrorMessage';
+import Unauthorized from '@/shared/components/Unauthorized';
+import { useSession } from 'next-auth/react';
 import Head from 'next/head';
 
 interface GraphPageProps {}
@@ -5,6 +8,20 @@ interface GraphPageProps {}
 interface GraphPageProps {}
 
 const GraphPage: React.FC<GraphPageProps> = () => {
+  const { data: session, status } = useSession();
+
+  if (status === 'loading') {
+    return <p>Loading...</p>;
+  }
+
+  if (status === 'unauthenticated') {
+    return <Unauthorized />;
+  }
+
+  if (!session?.user.merit) {
+    return <ErrorMessage message="You are not authorized to view this page." />;
+  }
+
   return (
     <div className="flex w-full flex-col">
       <Head>

--- a/src/pages/merit/professors/[professorId].tsx
+++ b/src/pages/merit/professors/[professorId].tsx
@@ -3,7 +3,7 @@ import { GetServerSideProps } from 'next';
 import { ActivityDto, UpdateActivityDto } from '@/models/activity.model';
 import { NarrativeDto } from '@/models/narrative.model';
 import { ProfessorInfoDto } from '@/models/professorInfo.model';
-import { getSession } from 'next-auth/react';
+import { getSession, useSession } from 'next-auth/react';
 import { getActivitiesByQuery, getActivityById } from '@/services/activity';
 import { bigintToJSON, toTitleCase } from '@/shared/utils/misc.util';
 import { getProfessorInfoForUser } from '@/services/professorInfo';
@@ -20,6 +20,7 @@ import { getUserById } from '@/services/user';
 import { getNarrativesForUser } from '@/services/narrative';
 import { seperateNarrativesByCategory } from '@/shared/utils/narrative.util';
 import TenureBadge from '@/components/ProfessorScoring/TenureBadge';
+import ErrorMessage from '@/shared/components/ErrorMessage';
 
 interface ProfessorScoringPageProps {
   activities?: ActivityDto[];
@@ -48,6 +49,14 @@ export const getServerSideProps: GetServerSideProps<
     return {
       props: {
         error: 'User not found.',
+      },
+    };
+  }
+
+  if (!session.user.merit) {
+    return {
+      props: {
+        error: 'You are not authorized to view this page.',
       },
     };
   }
@@ -114,6 +123,10 @@ const ProfessorScoringPage: React.FC<ProfessorScoringPageProps> = ({
     initialNarratives || [],
   );
   const [error, setError] = useState<string | null>(initialError || null);
+
+  if (error) {
+    return <ErrorMessage message={error} />;
+  }
 
   const updateActivity = (updatedActivity: UpdateActivityDto) => {
     updateActivityClient(updatedActivity).then((res) => {

--- a/src/pages/merit/professors/index.tsx
+++ b/src/pages/merit/professors/index.tsx
@@ -1,8 +1,25 @@
+import ErrorMessage from '@/shared/components/ErrorMessage';
+import Unauthorized from '@/shared/components/Unauthorized';
+import { useSession } from 'next-auth/react';
 import Head from 'next/head';
 
 interface ProfessorSearchPageProps {}
 
 const ProfessorSearchPage: React.FC<ProfessorSearchPageProps> = ({}) => {
+  const { data: session, status } = useSession();
+
+  if (status === 'loading') {
+    return <p>Loading...</p>;
+  }
+
+  if (status === 'unauthenticated') {
+    return <Unauthorized />;
+  }
+
+  if (!session?.user.merit) {
+    return <ErrorMessage message="You are not authorized to view this page." />;
+  }
+
   return (
     <div className="flex w-full flex-col">
       <Head>

--- a/src/pages/narratives/[category].tsx
+++ b/src/pages/narratives/[category].tsx
@@ -9,6 +9,7 @@ import {
 import { getActivitiesByQuery } from '@/services/activity';
 import { getNarrativeForUserForCategory } from '@/services/narrative';
 import Button from '@/shared/components/Button';
+import ErrorMessage from '@/shared/components/ErrorMessage';
 import { bigintToJSON, toTitleCase } from '@/shared/utils/misc.util';
 import { Activity, ActivityCategory, NarrativeCategory } from '@prisma/client';
 import moment from 'moment';
@@ -119,20 +120,10 @@ const NarrativeForm: React.FC<NarrativeFormProps> = ({
   };
 
   if (pageError || activities === undefined) {
-    return (
-      <p className="mt-20 w-full text-center text-red-500">
-        {' '}
-        Error: {pageError || 'Unknown Error'}
-      </p>
-    );
+    return error ? <ErrorMessage message={error} /> : <ErrorMessage />;
   }
-  if (!category)
-    return (
-      <p className="mt-20 w-full text-center text-red-500">
-        {' '}
-        Invalid Category{' '}
-      </p>
-    );
+
+  if (!category) return <ErrorMessage message="Invalid Category." />;
 
   const unfavoriteActivity = async (
     activityId: number,

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -1,5 +1,6 @@
 import ProfileContainer from '@/components/Profile/ProfileContainer';
 import { getUserWithInfo } from '@/services/user';
+import ErrorMessage from '@/shared/components/ErrorMessage';
 import { ProfileInformation } from '@/store/profile.store';
 import { GetServerSideProps } from 'next';
 import { getSession } from 'next-auth/react';
@@ -59,11 +60,7 @@ export const getServerSideProps: GetServerSideProps<ProfilePageProps> = async (
 
 const Profile: React.FC<ProfilePageProps> = ({ userId, info, error }) => {
   if (error || !info || !userId)
-    return (
-      <p className="mt-20 w-full text-center text-red-500">
-        Error: {error || 'unknown error.'}
-      </p>
-    );
+    return error ? <ErrorMessage message={error} /> : <ErrorMessage />;
 
   return (
     <div className="w-full">

--- a/src/shared/components/ErrorMessage.tsx
+++ b/src/shared/components/ErrorMessage.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface ErrorMessageProps {
+  message?: string;
+}
+
+const ErrorMessage: React.FC<ErrorMessageProps> = ({
+  message,
+}: ErrorMessageProps) => {
+  return (
+    <p className="mt-20 w-full text-center text-body-bold text-red-500">
+      Error: {message || 'Unknown Error'}
+    </p>
+  );
+};
+
+export default ErrorMessage;

--- a/src/shared/components/Header.tsx
+++ b/src/shared/components/Header.tsx
@@ -9,6 +9,7 @@ const Header: React.FC = () => {
   const { status } = useSession();
   const router = useRouter();
   const signedIn = status === 'authenticated';
+  const notSignOutPage = !(router.pathname === '/auth/signout');
 
   return (
     <div className="flex w-screen items-baseline bg-black px-5 py-3 font-bold">
@@ -23,7 +24,7 @@ const Header: React.FC = () => {
           />
         </a>
       </Link>
-      {signedIn && (
+      {signedIn && notSignOutPage && (
         <Button
           onClick={() => router.push('/api/auth/signout')}
           addOnClass="ml-auto my-auto mr-5"

--- a/src/shared/components/InfoSidebar.tsx
+++ b/src/shared/components/InfoSidebar.tsx
@@ -107,7 +107,7 @@ const InfoSidebar: React.FC = () => {
       )}
       {sidebarType === 'narratives' && <NarrativeInstructions />}
       {sidebarType === 'profile' && <ProfileInstructions />}
-      {sidebarType === 'scoring' && (
+      {sidebarType === 'scoring' && session?.user?.merit && (
         <>
           <ScoringInfo profInfo={professorInfo} />
           <ProfessorCommentBox professorId={professorId} />


### PR DESCRIPTION
Closes #115 

## Description
- Add `/merit/(.*)` to `middleware.ts`.
- Add role-based authentication to merit pages.

## Things you especially want reviewed
- Check if it works as intended with a faculty member and a merit committee member.
- Check the following routes and ensure that only the correct user roles can access these pages:
  - `/merit/professors`
  - `/merit/professors/[professorId]`
  - `/merit/dashboard`
  - `/merit/graphs`
  - `/admin`


## Screenshots if Applicable

## Checklist

- [x] Ticket number in PR title
- [x] Add ticket number to ("Closes #")
- [x] Move status to Code Review in GH Board
- [x] People added to reviewers
- [x] Asked for Review in Slack
