### PR TITLE
Show narrative text description with new lines from input (#118)

### DIFF
--- a/src/components/ProfessorScoring/NarrativeCard.tsx
+++ b/src/components/ProfessorScoring/NarrativeCard.tsx
@@ -51,7 +51,7 @@ const NarrativeCard: React.FC<NarrativeCardProps> = ({
             Narrative
           </div>
           {!expanded && (
-            <div className="relative w-fit text-small">
+            <div className="relative w-fit whitespace-pre-wrap text-small">
               {narrative ? shortenDescription(narrative?.text) : 'No narrative'}
             </div>
           )}

--- a/src/components/Submissions/SubmissionsInfo.tsx
+++ b/src/components/Submissions/SubmissionsInfo.tsx
@@ -82,7 +82,7 @@ const SubmissionsInfo: React.FC<SubmissionsInfoProps> = ({
         title="Narrative Preview"
         cookieKey="submissions-narrative-preview"
       >
-        <p className="mt-2">
+        <p className="mt-2 whitespace-pre-wrap">
           {' '}
           {narrative?.text || 'No narrative submitted yet.'}{' '}
         </p>


### PR DESCRIPTION
Closes #118

## Description

Added some CSS to render whitespace in displays. The input does save new lines, it's just an issue of how they end up displayed in the eventual HTML.

## Things you especially want reviewed

Check that I've amended all the areas where the full narrative is displayed: I've edited the NarrativeCard component and "narrative preview" in the sidebar of activity category pages shown to faculty.

## Screenshots if Applicable

<img width="1253" alt="Screen Shot 2023-11-12 at 5 31 21 PM" src="https://github.com/sandboxnu/faculty-activity-tracker/assets/45926251/d9d1e3e6-7bf6-4292-a8a0-1ed3926375ed">

## Checklist

- [x] Ticket number in PR title
- [x] Add ticket number to ("Closes #")
- [x] Move status to Code Review in GH Board
- [x] People added to reviewers
- [x] Asked for Review in Slack
