### PR TITLE
Display new lines in activity description on activity approval card (#120)

### DIFF
--- a/src/components/ProfessorScoring/ActivityApprovalCard.tsx
+++ b/src/components/ProfessorScoring/ActivityApprovalCard.tsx
@@ -191,7 +191,11 @@ const ActivityApprovalCard: React.FC<ActivityApprovalProp> = ({
           />
         </div>
       </div>
-      {expanded && <div className="text-regular">{activity?.description}</div>}
+      {expanded && (
+        <div className="text-regular whitespace-pre-wrap">
+          {activity?.description}
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Closes #120

## Description

Made a change in the Tailwind properties to preserve the new lines entered for the activity description upon display within the activity approval cards on the Merit Committee side.

## Things you especially want reviewed

Is that all we wanted to change?

## Screenshots if Applicable

<img width="1343" alt="Screen Shot 2023-11-13 at 10 58 35 PM" src="https://github.com/sandboxnu/faculty-activity-tracker/assets/45926251/3efcfb91-bcb2-4a1f-8164-3985ccf4ca34">

## Checklist

- [x] Ticket number in PR title
- [x] Add ticket number to ("Closes #")
- [x] Move status to Code Review in GH Board
- [x] People added to reviewers
- [x] Asked for Review in Slack
