### PR TITLE
[Deployment] Implement an additional provider for the dean

### DIFF
--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -58,7 +58,7 @@ const preview_providers = [
         id: '4',
         name: 'Dean TestUser',
         email: 'dean_test_user@husky.neu.edu',
-        image: 'https://i.pravatar.cc/150?u=admin_test_user',
+        image: 'https://i.pravatar.cc/150?u=dean_test_user',
       };
     },
     credentials: {},

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -49,6 +49,20 @@ const preview_providers = [
     },
     credentials: {},
   }),
+  // Dean Test User
+  CredentialsProvider({
+    name: 'DEAN_TEST_USER',
+    id: 'dean-test-provider',
+    async authorize() {
+      return {
+        id: '4',
+        name: 'Dean TestUser',
+        email: 'dean_test_user@husky.neu.edu',
+        image: 'https://i.pravatar.cc/150?u=admin_test_user',
+      };
+    },
+    credentials: {},
+  }),
 ];
 
 const production_providers = [


### PR DESCRIPTION
Closes #123 

## Description
- Added an additional `CredentialsProvider` for the `DEAN`. Can be useful for testing future dean functionality in Vercel preview environment.
- Added the dean user to the production database.

## Things you especially want reviewed
- Check if you can do all the planned actions when logged in as the `DEAN_TEST_USER` in a Vercel preview deployment.

## Screenshots if Applicable

## Checklist

- [x] Ticket number in PR title
- [x] Add ticket number to ("Closes #")
- [x] Move status to Code Review in GH Board
- [x] People added to reviewers
- [ ] Asked for Review in Slack
