### PR TITLE
fix(ui/scoring): Comment box and Score card sticky on scroll

### DIFF
--- a/src/shared/components/InfoSidebar.tsx
+++ b/src/shared/components/InfoSidebar.tsx
@@ -112,8 +112,10 @@ const InfoSidebar: React.FC = () => {
       {sidebarType === 'scoring' && session?.user?.merit && (
         <>
           <ScoringInfo profInfo={professorInfo} />
-          <ProfessorCommentBox professorId={professorId} />
-          <ProfessorScoreCard professorId={professorId} />
+          <div className="sticky top-4 w-full space-y-4">
+            <ProfessorCommentBox professorId={professorId} />
+            <ProfessorScoreCard professorId={professorId} />
+          </div>
         </>
       )}
     </div>


### PR DESCRIPTION
## Description

* Made the scoring card and comment box sticky on scroll. Makes scoring lot of activities easier.

## Things you especially want reviewed

## Screenshots if Applicable

## Checklist

- [ ] Ticket number in PR title
- [ ] Add ticket number to ("Closes #")
- [ ] Move status to Code Review in GH Board
- [ ] People added to reviewers
- [ ] Asked for Review in Slack
