### PR TITLE
fix(ui/faculty): increase z-index of tooltip in activity form

### DIFF
--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -19,7 +19,7 @@
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.25);
   border-radius: 18px;
   position: absolute;
-  z-index: 1;
+  z-index: 3;
   top: 100%;
   left: 0;
   width: max-content;
@@ -55,7 +55,7 @@
   border-radius: 2px;
   padding: 6px;
   position: absolute;
-  z-index: 1;
+  z-index: 3;
   pointer-events: none;
 }
 
@@ -109,7 +109,7 @@
   border-bottom: 6px solid white;
   margin-left: -6px;
   margin-top: -2px;
-  z-index: 1;
+  z-index: 3;
 }
 
 /* The outline of the left-pointing triangle */
@@ -128,7 +128,7 @@
   border-right: 6px solid white;
   margin-top: -6px;
   margin-right: -0.5px;
-  z-index: 1;
+  z-index: 3;
 }
 
 .infoTooltip:hover .infoTooltipText {


### PR DESCRIPTION
## Description

Fixes a visual overlay bug: increases the z-index of tooltips so that they always overlap on top of the DropdownInput (z-index = 2)

## Things you especially want reviewed

## Screenshots if Applicable
<img width="1440" alt="Screenshot 2023-12-10 at 12 49 26 PM" src="https://github.com/sandboxnu/faculty-activity-tracker/assets/57200118/0696b633-f0bb-416d-ad64-38e50d3d2c6f">

## Checklist

- [ ] Ticket number in PR title
- [ ] Add ticket number to ("Closes #")
- [ ] Move status to Code Review in GH Board
- [ ] People added to reviewers
- [ ] Asked for Review in Slack
